### PR TITLE
added flags to allow creation of a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,12 @@ c4core_add_library(c4core
     INC_DIRS ${C4CORE_SRC_DIR} ${C4CORE_EXT_DIR}
 )
 
+c4core_add_library(c4core-interface
+    LIBRARY_TYPE INTERFACE
+    SOURCES ${C4CORE_SRC} SOURCE_ROOT ${C4CORE_SRC_DIR}
+    INTERFACE_INC_DIRS ${C4CORE_SRC_DIR} ${C4CORE_EXT_DIR}
+)
+
 c4core_add_doxygen(doc
     PROJ c4core
     DOXYFILE ${CMAKE_CURRENT_LIST_DIR}/cmake/Doxyfile.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,6 @@ c4core_add_library(c4core
     INC_DIRS ${C4CORE_SRC_DIR} ${C4CORE_EXT_DIR}
 )
 
-c4core_add_library(c4core-interface
-    LIBRARY_TYPE INTERFACE
-    SOURCES ${C4CORE_SRC} SOURCE_ROOT ${C4CORE_SRC_DIR}
-    INTERFACE_INC_DIRS ${C4CORE_SRC_DIR} ${C4CORE_EXT_DIR}
-)
-
 c4core_add_doxygen(doc
     PROJ c4core
     DOXYFILE ${CMAKE_CURRENT_LIST_DIR}/cmake/Doxyfile.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,12 @@ set(C4CORE_SRC
     c4/c4core.natvis
 )
 
+if(NOT C4_LIBRARY_TYPE)
+    set(C4_LIBRARY_TYPE STATIC)
+endif()
+
 c4core_add_library(c4core
+    LIBRARY_TYPE ${RYML_LIBRARY_TYPE}  
     SOURCES ${C4CORE_SRC} SOURCE_ROOT ${C4CORE_SRC_DIR}
     INC_DIRS ${C4CORE_SRC_DIR} ${C4CORE_EXT_DIR}
 )


### PR DESCRIPTION
With `-DC4_LIBRARY_TYPE=SHARED`, CMake now builds an `so` file instead of an `a` file.