### PR TITLE
Fix of int to char narrowing conversion error

### DIFF
--- a/src/c4/base64.cpp
+++ b/src/c4/base64.cpp
@@ -33,7 +33,7 @@ constexpr static const char base64_sextet_to_char_[64] = {
 
 // https://www.cs.cmu.edu/~pattis/15-1XX/common/handouts/ascii.html
 constexpr static const char base64_char_to_sextet_[128] = {
-    #define __ -1 // undefined below
+    #define __ char(-1) // undefined below
     /*  0 NUL*/ __, /*  1 SOH*/ __, /*  2 STX*/ __, /*  3 ETX*/ __,
     /*  4 EOT*/ __, /*  5 ENQ*/ __, /*  6 ACK*/ __, /*  7 BEL*/ __,
     /*  8 BS */ __, /*  9 TAB*/ __, /* 10 LF */ __, /* 11 VT */ __,


### PR DESCRIPTION
Hi,

thanks for your work on rapidyaml.

The following change fixes narrowing conversions from int to char, which according to the C++ standard makes the program ill formed and causes build fails on some platforms. 
The failure can be reproduced for example with g++ 8.3.0 for ARM.
With this fix the build succeeds.

--Matus