### PR TITLE
Fixing charconv static assert for Microsoft STL C++20. 

### DIFF
--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -10,6 +10,7 @@
 #include <climits>
 #include <limits>
 #include <utility>
+#include <iterator>
 
 #if (C4_CPP >= 17)
 #   if defined(_MSC_VER)
@@ -126,7 +127,7 @@ inline C4_CONSTEXPR14 char to_c_fmt(RealFormat_e f)
         'g',  // FTOA_FLEX
         'a',  // FTOA_HEXA
     };
-    C4_STATIC_ASSERT(sizeof(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT(std::size(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }
@@ -141,7 +142,7 @@ inline constexpr std::chars_format to_std_fmt(RealFormat_e f)
         std::chars_format::general,     // FTOA_FLEX
         std::chars_format::hex,         // FTOA_HEXA
     };
-    C4_STATIC_ASSERT((sizeof(fmt)/sizeof(std::chars_format)) == _FTOA_COUNT);
+    C4_STATIC_ASSERT(std::size(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -10,7 +10,6 @@
 #include <climits>
 #include <limits>
 #include <utility>
-#include <iterator>
 
 #if (C4_CPP >= 17)
 #   if defined(_MSC_VER)
@@ -127,7 +126,7 @@ inline C4_CONSTEXPR14 char to_c_fmt(RealFormat_e f)
         'g',  // FTOA_FLEX
         'a',  // FTOA_HEXA
     };
-    C4_STATIC_ASSERT(std::size(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT(C4_COUNTOF(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }
@@ -142,7 +141,7 @@ inline constexpr std::chars_format to_std_fmt(RealFormat_e f)
         std::chars_format::general,     // FTOA_FLEX
         std::chars_format::hex,         // FTOA_HEXA
     };
-    C4_STATIC_ASSERT(std::size(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT(C4_COUNTOF(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -126,7 +126,7 @@ inline C4_CONSTEXPR14 char to_c_fmt(RealFormat_e f)
         'g',  // FTOA_FLEX
         'a',  // FTOA_HEXA
     };
-    C4_STATIC_ASSERT(sizeof(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT( std::size(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }
@@ -141,7 +141,7 @@ inline constexpr std::chars_format to_std_fmt(RealFormat_e f)
         std::chars_format::general,     // FTOA_FLEX
         std::chars_format::hex,         // FTOA_HEXA
     };
-    C4_STATIC_ASSERT(sizeof(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT(std::size(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -126,7 +126,7 @@ inline C4_CONSTEXPR14 char to_c_fmt(RealFormat_e f)
         'g',  // FTOA_FLEX
         'a',  // FTOA_HEXA
     };
-    C4_STATIC_ASSERT( std::size(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT(sizeof(fmt) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }
@@ -141,7 +141,7 @@ inline constexpr std::chars_format to_std_fmt(RealFormat_e f)
         std::chars_format::general,     // FTOA_FLEX
         std::chars_format::hex,         // FTOA_HEXA
     };
-    C4_STATIC_ASSERT(std::size(fmt) == _FTOA_COUNT);
+    C4_STATIC_ASSERT((sizeof(fmt)/sizeof(std::chars_format)) == _FTOA_COUNT);
     C4_ASSERT(f < _FTOA_COUNT);
     return fmt[f];
 }


### PR DESCRIPTION
Hey!

I've just found your library for parsing YAML files after getting tired of waiting 10 seconds to parse a 20mb YAML file with some _other_ library and been trying to build this on Clang C++20 with Microsoft STL, but ran into this issue where `enum class chars_format` is not strictly char so it ends up breaking this static assert (since `sizeof(...)` ends up 16). After the fix it should build for C++20 as well, C++11 was working fine eitherway it seems.
`C4_STATIC_ASSERT(sizeof(fmt) == _FTOA_COUNT);`

P.S. I had to include the `<iterator>` header for `std::size`, not sure if the changes fit the coding style of this repo since I've just cloned it so my apologies if it doesn't.