### PR TITLE
fix atoi resolution in gcc

### DIFF
--- a/src/c4/error.cpp
+++ b/src/c4/error.cpp
@@ -164,7 +164,7 @@ bool is_debugger_attached()
             tracer_pid = strstr(buf, TracerPid);
             if (tracer_pid)
             {
-                first_call_result = !!atoi(tracer_pid + sizeof(TracerPid) - 1);
+                first_call_result = !!::atoi(tracer_pid + sizeof(TracerPid) - 1);
             }
         }
     }


### PR DESCRIPTION
for some reason, atoi isn't resolved preporly for me:

```
/home/tim/dev/rapidyaml/ext/c4core/src/c4/error.cpp: In function ‘bool c4::is_debugger_attached()’:
/home/tim/dev/rapidyaml/ext/c4core/src/c4/error.cpp:167:78: error: no matching function for call to ‘atoi(char*)’
  167 |                 first_call_result = !!atoi(tracer_pid + sizeof(TracerPid) - 1);
      |                                                                              ^
In file included from /home/tim/dev/rapidyaml/src/c4/yml/././tree.hpp:10,
                 from /home/tim/dev/rapidyaml/src/c4/yml/./emit.hpp:9,
                 from /home/tim/dev/rapidyaml/src/c4/yml/emit.def.hpp:5,
                 from gp/rapidyaml.cpp:2:
/home/tim/dev/rapidyaml/ext/c4core/src/c4/charconv.hpp:481:6: note: candidate: ‘template<class T> bool c4::atoi(c4::csubstr, T*)’
  481 | bool atoi(csubstr str, T * C4_RESTRICT v)
      |      ^~~~
/home/tim/dev/rapidyaml/ext/c4core/src/c4/charconv.hpp:481:6: note:   template argument deduction/substitution failed:
In file included from gp/rapidyaml.cpp:8:
/home/tim/dev/rapidyaml/ext/c4core/src/c4/error.cpp:167:78: note:   candidate expects 2 arguments, 1 provided
  167 |                 first_call_result = !!atoi(tracer_pid + sizeof(TracerPid) - 1);
      |                                                                              ^
```