### PR TITLE
fix: build error on windows arm/arm64

### DIFF
--- a/src/c4/cpu.hpp
+++ b/src/c4/cpu.hpp
@@ -50,7 +50,8 @@
 #       elif defined(__ARM_ARCH_7__) || defined(_ARM_ARCH_7)      \
         || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) \
         || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__) \
-        || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 7)
+        || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 7) \
+        || (defined(_M_ARM) && _M_ARM >= 7)
 #            define C4_CPU_ARMV7
 #       elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
         || defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6Z__) \

--- a/src/c4/windows_push.hpp
+++ b/src/c4/windows_push.hpp
@@ -8,17 +8,22 @@
  *
  * @see https://aras-p.info/blog/2018/01/12/Minimizing-windows.h/ */
 
-#if defined(_WIN64)
+#if defined(_M_AMD64)
 #   ifndef _AMD64_
 #       define _c4_AMD64_
 #       define _AMD64_
 #   endif
-#elif defined(_WIN32)
+#elif defined(_M_IX86)
 #   ifndef _X86_
 #       define _c4_X86_
 #       define _X86_
 #   endif
-#elif defined(_ARM)
+#elif defined(_M_ARM64)
+#   ifndef _ARM64_
+#       define _c4_ARM64_
+#       define _ARM64_
+#   endif
+#elif defined(_M_ARM)
 #   ifndef _ARM_
 #       define _c4_ARM_
 #       define _ARM_


### PR DESCRIPTION
According to [Predefined macros](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros), `_WIN32` and `_WIN64` macros does not mean it's x86 or x64, it maybe ARM or ARM64.
The fast_float also has to update. (https://github.com/fastfloat/fast_float/pull/80)