### PR TITLE
[fix] fix build with C4CORE_NO_FAST_FLOAT (previous fix was incomplete)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
   #----------------------------------------------------------------------------
   coverage:
-    name: c++${{matrix.std}}
+    name: coverage/c++${{matrix.std}}
     # if: github.ref == 'refs/heads/master'
     continue-on-error: true
     if: always()  # https://stackoverflow.com/questions/62045967/github-actions-is-there-a-way-to-continue-on-error-while-still-getting-correct
@@ -62,9 +62,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {std: 11, cxx: g++-7, bt: Coverage, os: ubuntu-18.04}
-          - {std: 14, cxx: g++-7, bt: Coverage, os: ubuntu-18.04}
-          - {std: 17, cxx: g++-7, bt: Coverage, os: ubuntu-18.04}
+          - {std: 11, cxx: g++-7, cc: gcc-7, bt: Coverage, os: ubuntu-18.04}
+          - {std: 14, cxx: g++-7, cc: gcc-7, bt: Coverage, os: ubuntu-18.04}
+          - {std: 17, cxx: g++-7, cc: gcc-7, bt: Coverage, os: ubuntu-18.04}
     env: {STD: "${{matrix.std}}", CXX_: "${{matrix.cxx}}", BT: "${{matrix.bt}}", BITLINKS: "${{matrix.bitlinks}}", VG: "${{matrix.vg}}", SAN: "${{matrix.san}}", LINT: "${{matrix.lint}}", OS: "${{matrix.os}}", CODECOV_TOKEN: "${{secrets.CODECOV_TOKEN}}", COVERALLS_REPO_TOKEN: "${{secrets.COVERALLS_REPO_TOKEN}}"}
     steps:
       - {name: checkout, uses: actions/checkout@v2, with: {submodules: recursive}}
@@ -115,6 +115,60 @@ jobs:
           source .github/setenv.sh
           c4_submit_coverage static32 codecov
           #c4_submit_coverage static32 coveralls  # only accepts one submission per job
+
+  #----------------------------------------------------------------------------
+  coverage_nofastfloat:
+    name: coverage/c++${{matrix.std}}/nofastfloat
+    # if: github.ref == 'refs/heads/master'
+    continue-on-error: true
+    if: always()  # https://stackoverflow.com/questions/62045967/github-actions-is-there-a-way-to-continue-on-error-while-still-getting-correct
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {std: 11, cxx: g++-7, cc: gcc-7, bt: Coverage, os: ubuntu-18.04}
+          - {std: 14, cxx: g++-7, cc: gcc-7, bt: Coverage, os: ubuntu-18.04}
+          - {std: 17, cxx: g++-7, cc: gcc-7, bt: Coverage, os: ubuntu-18.04}
+    env: {
+      STD: "${{matrix.std}}",
+      CXX_: "${{matrix.cxx}}",
+      BT: "${{matrix.bt}}",
+      OS: "${{matrix.os}}",
+      CODECOV_TOKEN: "${{secrets.CODECOV_TOKEN}}",
+      COVERALLS_REPO_TOKEN: "${{secrets.COVERALLS_REPO_TOKEN}}",
+      BDIR:   "build/nofastfloat-${{matrix.cxx}}-cxx${{matrix.std}}",
+      IDIR: "install/nofastfloat-${{matrix.cxx}}-cxx${{matrix.std}}",
+    }
+    steps:
+      - {name: checkout, uses: actions/checkout@v2, with: {submodules: recursive}}
+      - {name: install requirements, run: source .github/reqs.sh && c4_install_test_requirements $OS}
+      - {name: show info, run: source .github/setenv.sh && c4_show_info}
+      - name: nofastfloat-configure------------------------------------------------
+        run: |
+          set -x
+          mkdir -p $BDIR
+          mkdir -p $IDIR
+          cmake -S . -B $BDIR \
+            -DC4_CXX_STANDARD=${{matrix.std}} \
+            -DC4CORE_CXX_STANDARD=${{matrix.std}} \
+            -DC4CORE_BUILD_TESTS=ON \
+            -DC4CORE_WITH_FASTFLOAT=OFF \
+            -DCMAKE_INSTALL_PREFIX=$IDIR \
+            -DCMAKE_BUILD_TYPE=Coverage \
+            -DCMAKE_CXX_COMPILER=${{matrix.cxx}} \
+            -DCMAKE_CXX_COMPILER=${{matrix.cc}}
+      - name: nofastfloat-build
+        run: |
+          cmake --build $BDIR --config Coverage --target c4core-test-build
+      - name: nofastfloat-run
+        run: |
+          cmake --build $BDIR --config Coverage --target c4core-test-run
+      - name: nofastfloat-submit
+        run: |
+          cmake --build $BDIR --config Coverage --target c4core-coverage-submit-codecov
+          #cmake --build $BDIR --config Coverage --target c4core-coverage-submit-coveralls
+
 
   #----------------------------------------------------------------------------
   windows:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,11 @@ c4_add_library(c4core
         c4/ext/fast_float/include/fast_float/simple_decimal_conversion.h
 )
 
+option(C4CORE_WITH_FASTFLOAT "use fastfloat to parse floats" ON)
+if(NOT C4CORE_WITH_FASTFLOAT)
+    target_compile_definitions(c4core PUBLIC -DC4CORE_NO_FAST_FLOAT)
+endif()
+
 
 #-------------------------------------------------------
 

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -99,7 +99,7 @@
 #endif
 
 
-#if C4CORE_HAVE_STD_FROMCHARS && !defined(C4CORE_HAVE_FAST_FLOAT)
+#if !C4CORE_HAVE_STD_FROMCHARS && !defined(C4CORE_HAVE_FAST_FLOAT)
 #include <cstdio>
 #endif
 
@@ -1055,7 +1055,7 @@ size_t print_one(substr str, const char* full_fmt, T v)
 #endif
 }
 
-#if C4CORE_HAVE_STD_FROMCHARS && !defined(C4CORE_HAVE_FAST_FLOAT)
+#if !C4CORE_HAVE_STD_FROMCHARS && !defined(C4CORE_HAVE_FAST_FLOAT)
 /** scans a string using the given type format, while at the same time
  * allowing non-null-terminated strings AND guaranteeing that the given
  * string length is strictly respected, so that no buffer overflows


### PR DESCRIPTION
I actually missed a small change I made locally when creating #42, which I only now realized after upgrading to rapidyaml 0.2.3. This PR updates my previous fix for C4CORE_NO_FAST_FLOAT builds.