### PR TITLE
[fix] make currtime() work on POSIX systems other than Linux

### DIFF
--- a/src/c4/platform.hpp
+++ b/src/c4/platform.hpp
@@ -23,7 +23,10 @@
 #   else
 #       error "Unknown Apple platform"
 #   endif
-#elif defined(__unix) || defined(__linux)
+#elif defined(__linux)
+#   define C4_UNIX
+#   define C4_LINUX
+#elif defined(__unix)
 #   define C4_UNIX
 #elif defined(__arm__) || defined(__aarch64__)
 #   define C4_ARM

--- a/src/c4/time.cpp
+++ b/src/c4/time.cpp
@@ -2,7 +2,7 @@
 
 #if defined(C4_WIN)
 #   include "c4/windows.hpp"
-#elif defined(C4_POSIX)
+#elif defined(C4_LINUX)
 #   include <time.h>
 #else
 #   include <chrono>
@@ -35,7 +35,7 @@ time_type currtime()
     QueryPerformanceCounter(&ts);
     time_type usecs = time_type(ts.QuadPart) * ifreq;
     return usecs;
-#elif defined(C4_POSIX)
+#elif defined(C4_LINUX)
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
     time_type usecs = time_type(1.e6) * time_type(ts.tv_sec)


### PR DESCRIPTION
Fixes #43.