### PR TITLE
Fix windows include on case-sensitive filesystem

### DIFF
--- a/src/c4/windows.hpp
+++ b/src/c4/windows.hpp
@@ -3,7 +3,7 @@
 
 #if defined(_WIN64) || defined(_WIN32)
 #include "c4/windows_push.hpp"
-#include <Windows.h>
+#include <windows.h>
 #include "c4/windows_pop.hpp"
 #endif
 


### PR DESCRIPTION
This fix cross build from Linux with mingw