### PR TITLE
:wrench: gcc-4.8.5 support

### DIFF
--- a/.github/reqs.sh
+++ b/.github/reqs.sh
@@ -189,6 +189,7 @@ function _c4_gather_compilers()
         g++-6      ) _c4_addgcc 6  ;;
         g++-5      ) _c4_addgcc 5  ;;
         #g++-4.9    ) _c4_addgcc 4.9 ;;  # https://askubuntu.com/questions/1036108/install-gcc-4-9-at-ubuntu-18-04
+        g++-4.8    ) _c4_addgcc 4.8 ;;
         clang++-12 ) _c4_addclang 12  ;;
         clang++-11 ) _c4_addclang 11  ;;
         clang++-10 ) _c4_addclang 10  ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,6 +239,8 @@ jobs:
           - {std: 20, cxx: g++-10     , bt: Release, os: ubuntu-18.04, bitlinks: shared64 static32}
           - {std: 11, cxx: g++-5      , bt: Debug  , os: ubuntu-18.04, bitlinks: shared64 static32}
           - {std: 11, cxx: g++-5      , bt: Release, os: ubuntu-18.04, bitlinks: shared64 static32}
+          - {std: 11, cxx: g++-4.8    , bt: Debug,   os: ubuntu-18.04, bitlinks: shared64 static32}
+          - {std: 11, cxx: g++-4.8    , bt: Release, os: ubuntu-18.04, bitlinks: shared64 static32}
     env: {STD: "${{matrix.std}}", CXX_: "${{matrix.cxx}}", BT: "${{matrix.bt}}", BITLINKS: "${{matrix.bitlinks}}", VG: "${{matrix.vg}}", SAN: "${{matrix.san}}", LINT: "${{matrix.lint}}", OS: "${{matrix.os}}"}
     steps:
       - {name: checkout, uses: actions/checkout@v2, with: {submodules: recursive}}
@@ -380,6 +382,8 @@ jobs:
           - {std: 11, cxx: g++-6, bt: Release, os: ubuntu-18.04}
           - {std: 11, cxx: g++-5, bt: Debug  , os: ubuntu-18.04}
           - {std: 11, cxx: g++-5, bt: Release, os: ubuntu-18.04}
+          - {std: 11, cxx: g++-4.8, bt: Debug, os: ubuntu-18.04}
+          - {std: 11, cxx: g++-4.8, bt: Release, os: ubuntu-18.04}
     env: {STD: "${{matrix.std}}", CXX_: "${{matrix.cxx}}", BT: "${{matrix.bt}}", BITLINKS: "${{matrix.bitlinks}}", VG: "${{matrix.vg}}", SAN: "${{matrix.san}}", LINT: "${{matrix.lint}}", OS: "${{matrix.os}}"}
     steps:
       - {name: checkout, uses: actions/checkout@v2, with: {submodules: recursive}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(c4core
     DESCRIPTION "Multiplatform low-level C++ utilities"
     HOMEPAGE_URL "https://github.com/biojppm/c4core"
     LANGUAGES CXX)
+include(./compat.cmake)
+
 c4_project(VERSION 0.1.8
     AUTHOR "Joao Paulo Magalhaes <dev@jpmag.me>")
 
@@ -22,6 +24,7 @@ set(C4CORE_SRC_FILES
     c4/char_traits.hpp
     c4/common.hpp
     c4/compiler.hpp
+    c4/compat/gcc-4.8.hpp
     c4/config.hpp
     c4/cpu.hpp
     c4/ctor_dtor.hpp

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -10,7 +10,7 @@
 - `csubstr`: add `count(csubstr)` overload.
 - Add support for RISC-V architectures ([PR #69](https://github.com/biojppm/c4core/issues/69)).
 - Add support for bare-metal compilation ([PR #64](https://github.com/biojppm/c4core/issues/64)).
-
+- gcc >= 4.8 support using polyfills for missing templates and features ([PR #68](https://github.com/biojppm/c4core/pull/68))
 
 ### Fixes
 

--- a/compat.cmake
+++ b/compat.cmake
@@ -1,0 +1,15 @@
+
+# old gcc-4.8 support
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND
+  (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 4.8) AND
+  (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
+
+  # header injection, required to compile external projects (not necessary for c4core)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -include ${CMAKE_CURRENT_SOURCE_DIR}/src/c4/compat/gcc-4.8.hpp")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include ${CMAKE_CURRENT_SOURCE_DIR}/src/c4/compat/gcc-4.8.hpp")
+
+  # c++17 compiler required
+  set(C4CORE_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+  # LLVM required
+  set(C4CORE_SANITIZE OFF CACHE BOOL "" FORCE)
+endif()

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -49,8 +49,10 @@
 
 #ifndef C4CORE_NO_FAST_FLOAT
     C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Wsign-conversion")
-    C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Warray-bounds")
-    C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Wshift-count-overflow")
+    C4_SUPPRESS_WARNING_GCC("-Warray-bounds")
+#if __GNUC__ >= 5
+    C4_SUPPRESS_WARNING_GCC("-Wshift-count-overflow")
+#endif
 #   include "c4/ext/fast_float.hpp"
     C4_SUPPRESS_WARNING_GCC_POP
 #   define C4CORE_HAVE_FAST_FLOAT 1

--- a/src/c4/compat/gcc-4.8.hpp
+++ b/src/c4/compat/gcc-4.8.hpp
@@ -1,0 +1,68 @@
+#ifndef _C4_COMPAT_GCC_4_8_HPP_
+#define _C4_COMPAT_GCC_4_8_HPP_
+
+#if __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+/* STL polyfills for old GNU compilers */
+
+_Pragma("GCC diagnostic ignored \"-Wshadow\"")
+
+#if __cplusplus
+#include <cstdint>
+#include <type_traits>
+
+namespace std {
+
+template<typename _Tp>
+struct is_trivially_copyable : public integral_constant<bool,
+    is_destructible<_Tp>::value && __has_trivial_destructor(_Tp) &&
+    (__has_trivial_constructor(_Tp) || __has_trivial_copy(_Tp) || __has_trivial_assign(_Tp))>
+{ };
+
+template<typename _Tp>
+using is_trivially_copy_constructible = has_trivial_copy_constructor<_Tp>;
+
+template<typename _Tp>
+using is_trivially_default_constructible = has_trivial_default_constructor<_Tp>;
+
+template<typename _Tp>
+using is_trivially_copy_assignable = has_trivial_copy_assign<_Tp>;
+
+/* not supported */
+template<typename _Tp>
+struct is_trivially_move_constructible : false_type
+{ };
+
+/* not supported */
+template<typename _Tp>
+struct is_trivially_move_assignable : false_type
+{ };
+
+inline void *align(size_t __align, size_t __size, void*& __ptr, size_t& __space) noexcept
+{
+    if (__space < __size)
+        return nullptr;
+    const auto __intptr = reinterpret_cast<uintptr_t>(__ptr);
+    const auto __aligned = (__intptr - 1u + __align) & -__align;
+    const auto __diff = __aligned - __intptr;
+    if (__diff > (__space - __size))
+        return nullptr;
+    else
+    {
+        __space -= __diff;
+        return __ptr = reinterpret_cast<void*>(__aligned);
+    }
+}
+typedef long double max_align_t ;
+
+}
+#else // __cplusplus
+
+#include <string.h>
+// see https://sourceware.org/bugzilla/show_bug.cgi?id=25399 (ubuntu gcc-4.8)
+#define memset(s, c, count) __builtin_memset(s, c, count)
+
+#endif // __cplusplus
+
+#endif // __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+
+#endif // _C4_COMPAT_GCC_4_8_HPP_

--- a/src/c4/compiler.hpp
+++ b/src/c4/compiler.hpp
@@ -99,12 +99,16 @@
 #       else
 #           define C4_GCC_VERSION C4_VERSION_ENCODED(__GNUC__, __GNUC_MINOR__, 0)
 #       endif
-// we do not support GCC < 5:
+#       if __GNUC__ < 5
+#           if __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+#               include "c4/compat/gcc-4.8.hpp"
+#           else
+// we do not support GCC < 4.8:
 //  * misses std::is_trivially_copyable
 //  * misses std::align
 //  * -Wshadow has false positives when a local function parameter has the same name as a method
-#       if __GNUC__ < 5
-#           error "GCC < 5 is not supported"
+#               error "GCC < 4.8 is not supported"
+#           endif
 #       endif
 #   endif
 #endif // defined(C4_WIN) && defined(_MSC_VER)

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -161,8 +161,13 @@ void do_std_containers_test(Alloc alloc)
     clear_mr(alloc);
 
     {
+#if !defined(__GNUC__) || (__GNUC__ >= 5)
+        /* constructor does not exist on gcc < 5) */
         AllocPair a = alloc;
         _map_string_int v(a);
+#else
+        _map_string_int v;
+#endif
         CHECK_EQ(v.size(), 0);
         v["foo"] = 0;
         v["bar"] = 1;

--- a/test/test_error.cpp
+++ b/test/test_error.cpp
@@ -97,7 +97,10 @@ struct ErrorCallbacks
     }
 };
 
-
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 8 && __GNUC__ < 5
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 TEST_CASE("ErrorCallbacks.default_obj")
 {
     ErrorCallbacks cb {};
@@ -108,6 +111,9 @@ TEST_CASE("ErrorCallbacks.default_obj")
     CHECK_EQ(cb.msg_part, nullptr);
     CHECK_EQ(cb.msg_end, nullptr);
 }
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 8 && __GNUC__ < 5
+#pragma GCC diagnostic pop
+#endif
 
 template<class ErrBhv>
 struct ErrorCallbacksBridgeFull

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -30,6 +30,12 @@ def amalgamate_c4core(filename: str,
 #define C4CORE_EXPORTS
 #endif
 """
+    required_gcc4_8_include = """// these includes are needed to work around conditional
+// includes in the gcc4.8 shim
+#include <cstdint>
+#include <type_traits>
+#include <cstring>
+"""
     srcblocks = [
         am.cmttext(f"""
 c4core - C++ utilities
@@ -56,6 +62,8 @@ INSTRUCTIONS:
         "src/c4/platform.hpp",
         "src/c4/cpu.hpp",
         "src/c4/compiler.hpp",
+        am.injcode(required_gcc4_8_include),
+        "src/c4/compat/gcc-4.8.hpp",
         "src/c4/language.hpp",
         "src/c4/types.hpp",
         "src/c4/config.hpp",


### PR DESCRIPTION
- Add polyfills for missing stl templates
- some move related type_traits are not available as builtins, support is dropped
- disable broken -Wshadow
- disable sanitize and benchmark features when old compiler is detected (both require recent compilers)

Note: no modifications will be required on cmake repo, it felt better to add a repo specific CMake file here, and modification on gtest were adding flags in global scope anyway (the -include are not needed to compile c4core itself).

I ran tests on Github (coverage fails du to missing creds) and ensure header was present in amalgamated version.
