### PR TITLE
[fix] properly supporty libc++ ABI namespaces

### DIFF
--- a/src/c4/std/vector_fwd.hpp
+++ b/src/c4/std/vector_fwd.hpp
@@ -11,40 +11,13 @@ namespace std {
 template<typename> class allocator;
 template<typename T, typename Alloc> class vector;
 } // namespace std
-#elif defined(_LIBCPP_VERSION) || defined(__APPLE_CC__)
-#   if defined(__EMSCRIPTEN__)
+#elif defined(_LIBCPP_ABI_NAMESPACE)
 namespace std {
-template<typename> class allocator;
-inline namespace __2 {
-template<typename T, typename Alloc> class vector;
-} // namespace __2
-} // namespace std
-#   else // !defined(__EMSCRIPTEN__)
-#       if !defined(__APPLE_CC__)
-namespace std {
-template<typename> class allocator;
-inline namespace __1 {
-template<typename T, typename Alloc> class vector;
-} // namespace __1
-} // namespace std
-#       else // defined(__APPLE_CC__)
-#           if (__clang_major__ >= 13)
-namespace std {
-template<typename> class allocator;
-inline namespace __1 {
-template<typename T, typename Alloc> class vector;
-} // namespace __1
-} // namespace std
-#           else // if __clang_major__ < 13
-namespace std {
-inline namespace __1 {
+inline namespace _LIBCPP_ABI_NAMESPACE {
 template<typename> class allocator;
 template<typename T, typename Alloc> class vector;
-} // namespace __1
+} // namespace _LIBCPP_ABI_NAMESPACE
 } // namespace std
-#           endif // __clang_major < 13
-#       endif // defined(__APPLE_CC__)
-#   endif // !defined(__EMSCRIPTEN__)
 #else
 #error "unknown standard library"
 #endif


### PR DESCRIPTION
This fixes Android NDK build which uses `__ndk1` namespace. And probably dozen other build systems where custom tags are used.