### PR TITLE
Add integer overflow detection feature

### DIFF
--- a/bm/bm_charconv.cpp
+++ b/bm/bm_charconv.cpp
@@ -986,14 +986,30 @@ xtoa_c4_to_chars(bm::State& st)
     report<T>(st);
 }
 
-template<class T>
-void atox_c4_from_chars(bm::State& st)
+struct with_overflow_checked {};
+
+template<class T, class opt = void>
+typename  std::enable_if<std::is_same<opt, void>::value>::type
+atox_c4_from_chars(bm::State& st)
 {
     random_strings strings = mkstrings<T>();
     T val;
     for(auto _ : st)
     {
         c4::from_chars(strings.next(), &val);
+    }
+    report<T>(st);
+}
+
+template<class T, class opt = void>
+typename std::enable_if<std::is_same<opt, with_overflow_checked>::value>::type
+atox_c4_from_chars(bm::State& st)
+{
+    random_strings strings = mkstrings<T>();
+    T val;
+    for(auto _ : st)
+    {
+        c4::from_chars(strings.next(), c4::fmt::overflow_checked(val));
     }
     report<T>(st);
 }
@@ -1180,6 +1196,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, uint8_t);
 C4BM_TEMPLATE(atox_c4_atou,  uint8_t);
 C4BM_TEMPLATE(atox_c4_atox,  uint8_t);
 C4BM_TEMPLATE(atox_c4_from_chars, uint8_t);
+C4BM_TEMPLATE(atox_c4_from_chars, uint8_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, uint8_t);
 C4BM_TEMPLATE(atox_std_atoi,   uint8_t);
 C4BM_TEMPLATE(atox_std_strtoul,   uint8_t);
@@ -1194,6 +1211,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, int8_t);
 C4BM_TEMPLATE(atox_c4_atoi,   int8_t);
 C4BM_TEMPLATE(atox_c4_atox,   int8_t);
 C4BM_TEMPLATE(atox_c4_from_chars, int8_t);
+C4BM_TEMPLATE(atox_c4_from_chars, int8_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, int8_t);
 C4BM_TEMPLATE(atox_std_atoi,   int8_t);
 C4BM_TEMPLATE(atox_std_strtol,   int8_t);
@@ -1208,6 +1226,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, uint16_t);
 C4BM_TEMPLATE(atox_c4_atou, uint16_t);
 C4BM_TEMPLATE(atox_c4_atox, uint16_t);
 C4BM_TEMPLATE(atox_c4_from_chars, uint16_t);
+C4BM_TEMPLATE(atox_c4_from_chars, uint16_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, uint16_t);
 C4BM_TEMPLATE(atox_std_atoi,   uint16_t);
 C4BM_TEMPLATE(atox_std_strtoul,   uint16_t);
@@ -1222,6 +1241,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, int16_t);
 C4BM_TEMPLATE(atox_c4_atoi,  int16_t);
 C4BM_TEMPLATE(atox_c4_atox,  int16_t);
 C4BM_TEMPLATE(atox_c4_from_chars, int16_t);
+C4BM_TEMPLATE(atox_c4_from_chars, int16_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, int16_t);
 C4BM_TEMPLATE(atox_std_atoi,   int16_t);
 C4BM_TEMPLATE(atox_std_strtol,   int16_t);
@@ -1236,6 +1256,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, uint32_t);
 C4BM_TEMPLATE(atox_c4_atou, uint32_t);
 C4BM_TEMPLATE(atox_c4_atox, uint32_t);
 C4BM_TEMPLATE(atox_c4_from_chars, uint32_t);
+C4BM_TEMPLATE(atox_c4_from_chars, uint32_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, uint32_t);
 C4BM_TEMPLATE(atox_std_atoi,   uint32_t);
 C4BM_TEMPLATE(atox_std_strtoul,   uint32_t);
@@ -1250,6 +1271,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, int32_t);
 C4BM_TEMPLATE(atox_c4_atoi,  int32_t);
 C4BM_TEMPLATE(atox_c4_atox,  int32_t);
 C4BM_TEMPLATE(atox_c4_from_chars, int32_t);
+C4BM_TEMPLATE(atox_c4_from_chars, int32_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, int32_t);
 C4BM_TEMPLATE(atox_std_atoi,   int32_t);
 C4BM_TEMPLATE(atox_std_strtol,   int32_t);
@@ -1264,6 +1286,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, uint64_t);
 C4BM_TEMPLATE(atox_c4_atou, uint64_t);
 C4BM_TEMPLATE(atox_c4_atox, uint64_t);
 C4BM_TEMPLATE(atox_c4_from_chars, uint64_t);
+C4BM_TEMPLATE(atox_c4_from_chars, uint64_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, uint64_t);
 C4BM_TEMPLATE(atox_std_atol,   uint64_t);
 C4BM_TEMPLATE(atox_std_strtoull,   uint64_t);
@@ -1278,6 +1301,7 @@ C4BM_TEMPLATE(atox_c4_read_bin, int64_t);
 C4BM_TEMPLATE(atox_c4_atoi,  int64_t);
 C4BM_TEMPLATE(atox_c4_atox,  int64_t);
 C4BM_TEMPLATE(atox_c4_from_chars, int64_t);
+C4BM_TEMPLATE(atox_c4_from_chars, int64_t, with_overflow_checked);
 C4BM_TEMPLATE_CPP17(atox_std_from_chars, int64_t);
 C4BM_TEMPLATE(atox_std_atol,   int64_t);
 C4BM_TEMPLATE(atox_std_strtoll,   int64_t);

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -971,58 +971,42 @@ template<class T> struct overflow_max {};
 template<> struct overflow_max<uint8_t>
 {
     static csubstr value_dec() { return csubstr("255"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 3) || (str.len == 3 && str[0] <= '3'));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 3) || (str.len == 3 && str[0] <= '3')); }
 };
 template<> struct overflow_max<uint16_t>
 {
     static csubstr value_dec() { return csubstr("65535"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 6) || (str.len == 6 && str[0] <= '1'));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 6) || (str.len == 6 && str[0] <= '1')); }
 };
 template<> struct overflow_max<uint32_t>
 {
     static csubstr value_dec() { return csubstr("4294967295"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 11) || (str.len == 11 && str[0] <= '3'));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 11) || (str.len == 11 && str[0] <= '3')); }
 };
 template<> struct overflow_max<uint64_t>
 {
     static csubstr value_dec() { return csubstr("18446744073709551615"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 22) || (str.len == 22 && str[0] <= '1'));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 22) || (str.len == 22 && str[0] <= '1')); }
 };
 template<> struct overflow_max<int8_t>
 {
     static csubstr value_dec() { return csubstr("127"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 3) || (str.len == 3 && str[0] <= '1'));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 3) || (str.len == 3 && str[0] <= '1')); }
 };
 template<> struct overflow_max<int16_t>
 {
     static csubstr value_dec() { return csubstr("32767"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 6));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 6)); }
 };
 template<> struct overflow_max<int32_t>
 {
     static csubstr value_dec() { return csubstr("2147483647"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 11) || (str.len == 11 && str[0] <= '1'));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 11) || (str.len == 11 && str[0] <= '1')); }
 };
 template<> struct overflow_max<int64_t>
 {
     static csubstr value_dec() { return csubstr("9223372036854775807"); }
-    static bool is_oct_overflow(csubstr str) {
-        return !((str.len < 22));
-    }
+    static bool is_oct_overflow(csubstr str) { return !((str.len < 22)); }
 };
 
 

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -210,8 +210,21 @@ inline integral_<T> bin(T v)
     return integral_<T>(v, T(2));
 }
 
-} // namespace fmt
+template<class T>
+struct overflow_checked_
+{
+    static_assert(std::is_integral<T>::value, "range checking only for integral types");
+    C4_ALWAYS_INLINE overflow_checked_(T &val_) : val(&val_) {}
+    T *val;
+};
 
+template<class T>
+C4_ALWAYS_INLINE overflow_checked_<T> overflow_checked(T &val)
+{
+   return overflow_checked_<T>(val);
+}
+
+} // namespace fmt
 
 /** format an integral_ signed type */
 template<typename T>
@@ -247,6 +260,13 @@ to_chars(substr buf, fmt::integral_padded_<T> fmt)
     return utoa(buf, fmt.val, fmt.radix, fmt.num_digits);
 }
 
+template<class T>
+C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> wrapper)
+{
+    if(overflows<T>(s))
+        return false;
+    return atox(s, wrapper.val);
+}
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/test/test_charconv.cpp
+++ b/test/test_charconv.cpp
@@ -1313,11 +1313,11 @@ test_overflows()
 
         uint64_t max = (uint64_t) std::numeric_limits<T>::max();
         size_t sz = utoa<uint64_t>(s, max, (uint64_t)radix);
-        ASSERT_LE(sz, s.size());
+        REQUIRE_LE(sz, s.size());
         CHECK(!overflows<T>(s.first(sz)));
         memset(s.str, 0, s.len);
         sz = utoa<uint64_t>(s, max + 1, (uint64_t)radix);
-        ASSERT_LE(sz, s.size());
+        REQUIRE_LE(sz, s.size());
         CHECK(overflows<T>(s.first(sz)));
     }
 
@@ -1336,22 +1336,22 @@ test_overflows()
         substr s(bufc);
         INFO("radix=" << radix << " num=" << s);
 
-        uint64_t max = (uint64_t) std::numeric_limits<T>::max();
-        size_t sz = itoa<uint64_t>(s, max, (uint64_t)radix);
-        ASSERT_LE(sz, s.size());
+        int64_t max = (int64_t) std::numeric_limits<T>::max();
+        size_t sz = itoa<int64_t>(s, max, (int64_t)radix);
+        REQUIRE_LE(sz, s.size());
         CHECK(!overflows<T>(s.first(sz)));
         memset(s.str, 0, s.len);
-        sz = itoa<uint64_t>(s, max + 1, (uint64_t)radix);
-        ASSERT_LE(sz, s.size());
+        sz = itoa<int64_t>(s, max + 1, (int64_t)radix);
+        REQUIRE_LE(sz, s.size());
         CHECK(overflows<T>(s.first(sz)));
 
         int64_t min = (int64_t) std::numeric_limits<T>::min();
         sz = itoa<int64_t>(s, min, (int64_t)radix);
-        ASSERT_LE(sz, s.size());
+        REQUIRE_LE(sz, s.size());
         CHECK(!overflows<T>(s.first(sz)));
         memset(s.str, 0, s.len);
         sz = itoa<int64_t>(s, min - 1, (int64_t)radix);
-        ASSERT_LE(sz, s.size());
+        REQUIRE_LE(sz, s.size());
         CHECK(overflows<T>(s.first(sz)));
     }
 

--- a/test/test_charconv.cpp
+++ b/test/test_charconv.cpp
@@ -1364,6 +1364,7 @@ TEST_CASE("overflows.zeroes")
 {
     test_no_overflows<int>({ "", "0", "000", "0b0", "0B0", "0x0", "0X0", "0o0", "0O0" });
     test_no_overflows<int>({ "-", "-0", "-000", "-0b0", "-0B0", "-0x0", "-0X0", "-0o0", "-0O0" });
+    test_no_overflows<unsigned int>({ "", "0", "000", "0b0", "0B0", "0x0", "0X0", "0o0", "0O0" });
 }
 
 TEST_CASE_TEMPLATE("overflows.8bit_32bit", T, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t)
@@ -1373,8 +1374,12 @@ TEST_CASE_TEMPLATE("overflows.8bit_32bit", T, uint8_t, int8_t, uint16_t, int16_t
 
 TEST_CASE("overflows.u64")
 {
+    CHECK(!overflows<uint64_t>("18446744073709551614"));
     CHECK(!overflows<uint64_t>("18446744073709551615"));
     CHECK(overflows<uint64_t>("18446744073709551616"));
+
+    // more chars but leading zeroes
+    CHECK(!overflows<uint64_t>("0018446744073709551615"));
     
     { /* with leading zeroes */
         std::string str;
@@ -1393,10 +1398,15 @@ TEST_CASE("overflows.u64")
 
 TEST_CASE("overflows.i64")
 {
+    CHECK(!overflows<int64_t>("9223372036854775806"));
     CHECK(!overflows<int64_t>("9223372036854775807"));
     CHECK(overflows<int64_t>("9223372036854775808"));
     CHECK(!overflows<int64_t>("-9223372036854775808"));
     CHECK(overflows<int64_t>("-9223372036854775809"));
+
+    // more chars, but leading zeroes
+    CHECK(!overflows<int64_t>("0009223372036854775807"));
+    CHECK(!overflows<int64_t>("-0009223372036854775807"));
     
     { /* with leading zeroes */
         std::string str;

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -147,6 +147,17 @@ TEST_CASE_TEMPLATE("to_chars.fmt.zpad", T, uint8_t, int8_t)
     CHECK_EQ(to_chars_sub(buf, zpad(oct(nullptr), 5u)), "0o00000");
 }
 
+TEST_CASE("from_chars.fmt.overflow_checked")
+{
+    /* overflows<T>() is tested separatedly */
+    uint8_t val = 1;
+    using namespace fmt;
+    CHECK(from_chars(to_csubstr("255"), overflow_checked(val)));
+    CHECK_EQ(255, val);
+    val = 1;
+    CHECK(!from_chars(to_csubstr("256"), overflow_checked(val)));
+    CHECK_EQ(1, val);
+}
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Rework of https://github.com/biojppm/c4core/pull/75

- added bool overflows<T>(csubstr) function
- added fmt::overflow_checked() formatter

Overhead is 10-15% (when it was more 15-20% with previous implementation), I think overhead on u8 and i8 is more important just because there are more numbers with 3 digits spread on the domain (60%) so it has to compare bytes more often.

Also did not benchmark with hex/oct/bin encodings.

![overflow_checked](https://user-images.githubusercontent.com/417230/156552734-e025f20f-4196-4ceb-9e95-5daf5f66126e.png)
[overflow_checked.json.txt](https://github.com/biojppm/c4core/files/8177287/overflow_checked.json.txt)

I did not add atoi_rc, it felt a bit too much, instead it may be interesting to implement a couple helpers at RapidYaml level (overriding `operator>>`), ex:
```cpp
// on error (overflow included) v will default to "10"
node["test"] >> fmt::default_to(v, 10);

// fetch v check if it's in range [0, 100] on error or out of range default to "10"
node["test"] >> fmt::default_range(v, { 0, 100 }, 10);

// fetch v check if it's in range [0, 100] on out of range trigger an error
node["test"] >> fmt::range_checked(v, { 0, 100 });
```

What do you think ?

I can keep this as an extension to RapidYaml on our side if you'd prefer.