### PR TITLE
[fix] fix compile error in armel

### DIFF
--- a/src/c4/cpu.hpp
+++ b/src/c4/cpu.hpp
@@ -58,6 +58,7 @@
         || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 6)
            #define C4_CPU_ARMV6
        #elif defined(__ARM_ARCH_5TEJ__) \
+        || defined(__ARM_ARCH_5TE__) \
         || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 5)
            #define C4_CPU_ARMV5
        #elif defined(__ARM_ARCH_4T__) \


### PR DESCRIPTION
c4core fails to build on Debian bookworm/sid for armel as follows.

```
/<<PKGBUILDDIR>>/third_party/rapidyaml/rapidyaml/ext/c4core/src/c4/cpu.hpp:68:13: error: #error "unknown CPU architecture: ARM"
   68 | #           error "unknown CPU architecture: ARM"
      |             ^~~~~
```
Kindly find the following log for details of the build error:
https://buildd.debian.org/status/fetch.php?pkg=jsonnet&arch=armel&ver=0.18.0%2Bds-1&stamp=1655744320&raw=0

This patch tries to address this issue.

If things are satisfactory, please consider merging this pull request.

Thanks and regards,
Fukui