### PR TITLE
Adds missing fully qualified arm arch version.

### DIFF
--- a/src/c4/cpu.hpp
+++ b/src/c4/cpu.hpp
@@ -48,6 +48,7 @@
        #elif defined(__ARM_ARCH_7__) || defined(_ARM_ARCH_7)    \
         || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) \
         || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__) \
+        || defined(__ARM_ARCH_7EM__) \
         || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 7) \
         || (defined(_M_ARM) && _M_ARM >= 7)
            #define C4_CPU_ARMV7


### PR DESCRIPTION
When building for our platform got #error "unknown CPU architecture: ARM"
The fully qualified arm version for our platform  which specifies the FPU is __ARM_ARCH_7EM__

$ echo | arm-none-eabi-gcc -dM -E -mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 - | grep ARCH
#define __ARM_ARCH_PROFILE 77
#define __ARM_ARCH_ISA_THUMB 2
#define __ARM_ARCH 7
#define __ARM_ARCH_7EM__ 1
#define __ARM_ARCH_EXT_IDIV__ 1

This was missing in cpu.hpp, hence the PR.