### PR TITLE
Better predefined macros for platform detection

### DIFF
--- a/src/c4/platform.hpp
+++ b/src/c4/platform.hpp
@@ -23,7 +23,7 @@
 #   else
 #       error "Unknown Apple platform"
 #   endif
-#elif defined(__linux)
+#elif defined(__linux__) || defined(__linux)
 #   define C4_UNIX
 #   define C4_LINUX
 #elif defined(__unix)
@@ -36,7 +36,7 @@
 #   error "unknown platform"
 #endif
 
-#if defined(__posix) || defined(__unix__) || defined(__linux)
+#if defined(__posix) || defined(__unix__) || defined(C4_LINUX)
 #   define C4_POSIX
 #endif
 

--- a/src/c4/platform.hpp
+++ b/src/c4/platform.hpp
@@ -26,7 +26,7 @@
 #elif defined(__linux__) || defined(__linux)
 #   define C4_UNIX
 #   define C4_LINUX
-#elif defined(__unix)
+#elif defined(__unix__) || defined(__unix)
 #   define C4_UNIX
 #elif defined(__arm__) || defined(__aarch64__)
 #   define C4_ARM
@@ -36,7 +36,7 @@
 #   error "unknown platform"
 #endif
 
-#if defined(__posix) || defined(__unix__) || defined(C4_LINUX)
+#if defined(__posix) || defined(C4_UNIX) || defined(C4_LINUX)
 #   define C4_POSIX
 #endif
 


### PR DESCRIPTION
Please see the full commit messages for details. This (ratther oddly) fixes failure to compile on the ppc64le version of Red Hat Enterprise Linux 8.

The `__unix__` change is just for completeness/symmetry.