### PR TITLE
Fix build on FreeBSD/armv6

### DIFF
--- a/src/c4/cpu.hpp
+++ b/src/c4/cpu.hpp
@@ -55,7 +55,7 @@
        #elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
         || defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6Z__) \
         || defined(__ARM_ARCH_6K__)  || defined(__ARM_ARCH_6ZK__) \
-        || defined(__ARM_ARCH_6M__) \
+        || defined(__ARM_ARCH_6M__) || defined(__ARM_ARCH_6KZ__) \
         || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 6)
            #define C4_CPU_ARMV6
        #elif defined(__ARM_ARCH_5TEJ__) \


### PR DESCRIPTION
There is a missing check for __ARM_ARCH_6KZ__.