### PR TITLE
Add LoongArch cpu support.

### DIFF
--- a/src/c4/cpu.hpp
+++ b/src/c4/cpu.hpp
@@ -135,6 +135,16 @@
 #   define C4_BYTE_ORDER _C4EL
 #   define C4_WORDSIZE 4
 
+#elif defined(__loongarch__)
+#   if defined(__loongarch64)
+#       define C4_CPU_LOONGARCH64
+#       define C4_WORDSIZE 8
+#   else
+#       define C4_CPU_LOONGARCH
+#       define C4_WORDSIZE 4
+#   endif
+#   define C4_BYTE_ORDER _C4EL
+
 #elif defined(SWIG)
 #   error "please define CPU architecture macros when compiling with swig"
 


### PR DESCRIPTION
LoongArch is a new architecture that is already supported by linux-6.1, gcc-12, and I want to add LoongArch support for c4core.