### PR TITLE
Support _GLIBCXX_DEBUG

### DIFF
--- a/src/c4/std/vector_fwd.hpp
+++ b/src/c4/std/vector_fwd.hpp
@@ -13,7 +13,13 @@ __pragma(warning(disable : 4643))
 #endif
 namespace std {
 template<typename> class allocator;
+#ifdef _GLIBCXX_DEBUG
+inline namespace __debug {
 template<typename T, typename Alloc> class vector;
+}
+#else
+template<typename T, typename Alloc> class vector;
+#endif
 } // namespace std
 #if defined(_MSC_VER)
 __pragma(warning(pop))


### PR DESCRIPTION
libstdc++ has a special debug mode, which is enabled by #define-ing _GLIBCXX_DEBUG. In this mode std::vector is actually std::__debug::vector. Adjust the vector forward declaration to make the code build when _GLIBCXX_DEBUG is defined.

This is needed to build rapidyaml together with _GLIBCXX_DEBUG.

See https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html for some details on _GLIBCXX_DEBUG.