### PR TITLE
[fix] ensure gcc 4.8 compat header is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(C4CORE_SRC_FILES
     c4/export.hpp
     c4/format.hpp
     c4/format.cpp
+    c4/gcc-4.8.hpp
     c4/hash.hpp
     c4/language.hpp
     c4/language.cpp

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -49,8 +49,9 @@ assert(to_substr((char*)ptr).len == 3); // as before
 
 - [PR#115](https://github.com/biojppm/c4core/pull/115) - Refactor of `c4::blob`/`c4::cblob`. Use SFINAE to invalidate some of the constructors.
 - [PR#110](https://github.com/biojppm/c4core/pull/110)/[PR#107](https://github.com/biojppm/c4core/pull/107) - Update fast_float.
-- [PR#108](https://github.com/biojppm/c4core/pull/108) - Fix preprocessor pasting of strings in `C4_NOT_IMPLEMENTED_MSG()` and `C4_NOT_IMPLEMENTED_IF_MSG()`.
+- [PR#108](https://github.com/biojppm/c4core/pull/108) - Fix preprocessor concatenation of strings in `C4_NOT_IMPLEMENTED_MSG()` and `C4_NOT_IMPLEMENTED_IF_MSG()`.
 - [PR#106](https://github.com/biojppm/c4core/pull/106) - Fix include guard in the gcc 4.8 compatibility header, causing it to be missing from the amalgamated header.
+- [PR#123](https://github.com/biojppm/c4core/pull/123) - Ensure the gcc 4.8 compatibility header is installed (fixes [#103](https://github.com/biojppm/c4core/issues/103)).
 - [PR#105](https://github.com/biojppm/c4core/pull/105) - Fix existing throw in `c4/ext/sg14/inplace_function.h`. Ensure tests run with exceptions disabled and RTTI disabled. Add examples of exceptional control flow with `setjmp()/std::longjmp()`.
 - [PR#104](https://github.com/biojppm/c4core/pull/104)/[PR#112](https://github.com/biojppm/c4core/pull/112) - Fix pedantic warnings in gcc, clang and MSVC
 - [PR#104](https://github.com/biojppm/c4core/pull/104) - Fix possible compile error when `__GNUC__` is not defined

--- a/src/c4/gcc-4.8.hpp
+++ b/src/c4/gcc-4.8.hpp
@@ -1,0 +1,72 @@
+#ifndef _C4_GCC_4_8_HPP_
+#define _C4_GCC_4_8_HPP_
+
+#if __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+/* STL polyfills for old GNU compilers */
+
+_Pragma("GCC diagnostic ignored \"-Wshadow\"")
+_Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")
+
+#if __cplusplus
+#include <cstdint>
+#include <type_traits>
+
+namespace std {
+
+template<typename _Tp>
+struct is_trivially_copyable : public integral_constant<bool,
+    is_destructible<_Tp>::value && __has_trivial_destructor(_Tp) &&
+    (__has_trivial_constructor(_Tp) || __has_trivial_copy(_Tp) || __has_trivial_assign(_Tp))>
+{ };
+
+template<typename _Tp>
+using is_trivially_copy_constructible = has_trivial_copy_constructor<_Tp>;
+
+template<typename _Tp>
+using is_trivially_default_constructible = has_trivial_default_constructor<_Tp>;
+
+template<typename _Tp>
+using is_trivially_copy_assignable = has_trivial_copy_assign<_Tp>;
+
+/* not supported */
+template<typename _Tp>
+struct is_trivially_move_constructible : false_type
+{ };
+
+/* not supported */
+template<typename _Tp>
+struct is_trivially_move_assignable : false_type
+{ };
+
+inline void *align(size_t __align, size_t __size, void*& __ptr, size_t& __space) noexcept
+{
+    if (__space < __size)
+        return nullptr;
+    const auto __intptr = reinterpret_cast<uintptr_t>(__ptr);
+    const auto __aligned = (__intptr - 1u + __align) & -__align;
+    const auto __diff = __aligned - __intptr;
+    if (__diff > (__space - __size))
+        return nullptr;
+    else
+    {
+        __space -= __diff;
+        return __ptr = reinterpret_cast<void*>(__aligned);
+    }
+}
+
+#if __GNUC__ == 4 && __GNUC_MINOR__ == 8
+typedef long double max_align_t ;
+#endif
+
+}
+#else // __cplusplus
+
+#include <string.h>
+// see https://sourceware.org/bugzilla/show_bug.cgi?id=25399 (ubuntu gcc-4.8)
+#define memset(s, c, count) __builtin_memset(s, c, count)
+
+#endif // __cplusplus
+
+#endif // __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+
+#endif // _C4_GCC_4_8_HPP_

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -68,7 +68,7 @@ INSTRUCTIONS:
         "src/c4/platform.hpp",
         "src/c4/cpu.hpp",
         am.injcode(required_gcc4_8_include),
-        "cmake/compat/c4/gcc-4.8.hpp",
+        "src/c4/gcc-4.8.hpp",
         "src/c4/compiler.hpp",
         "src/c4/language.hpp",
         "src/c4/types.hpp",


### PR DESCRIPTION
re #103

This duplicates the gcc 4.8 compat header. It's a good-enough trade-off for the fact that it needs to be installed, and not having `c4_add_target()` add the include dir. The header contents are stable enough to withstand the duplication from the cmake project (which is needed because gtest does not compile on 4.8 without this header being injected with `-include`). 