### PR TITLE
[update] add Android support for API 16+

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -51,6 +51,7 @@ assert(to_substr((char*)ptr).len == 3); // as before
 
 ### Fixes
 
+- [PR#129](https://github.com/biojppm/c4core/pull/129) - Support android by enabling `aalloc()`'s call to `memalign()`, available for API 16+.
 - [PR#115](https://github.com/biojppm/c4core/pull/115) - Refactor of `c4::blob`/`c4::cblob`. Use SFINAE to invalidate some of the constructors.
 - [PR#110](https://github.com/biojppm/c4core/pull/110)/[PR#107](https://github.com/biojppm/c4core/pull/107) - Update fast_float.
 - [PR#108](https://github.com/biojppm/c4core/pull/108) - Fix preprocessor concatenation of strings in `C4_NOT_IMPLEMENTED_MSG()` and `C4_NOT_IMPLEMENTED_IF_MSG()`.

--- a/src/c4/memory_resource.cpp
+++ b/src/c4/memory_resource.cpp
@@ -42,7 +42,7 @@ void* aalloc_impl(size_t size, size_t alignment)
 #if defined(C4_WIN) || defined(C4_XBOX)
     mem = ::_aligned_malloc(size, alignment);
     C4_CHECK(mem != nullptr || size == 0);
-#elif defined(C4_ARM)
+#elif defined(C4_ARM) || defined(C4_ANDROID)
     // https://stackoverflow.com/questions/53614538/undefined-reference-to-posix-memalign-in-arm-gcc
     // https://electronics.stackexchange.com/questions/467382/e2-studio-undefined-reference-to-posix-memalign/467753
     mem = memalign(alignment, size);


### PR DESCRIPTION
Concerning the issue : [#127](https://github.com/biojppm/c4core/issues/127)
memalign was added for Android API since version 16. Adding this permits us to build c4core in android_armv8 and android_x86_64.