### PR TITLE
Please add C4_MINGW macro for rapidyaml 0.7.0

### DIFF
--- a/src/c4/compiler.hpp
+++ b/src/c4/compiler.hpp
@@ -93,6 +93,9 @@
 #           define C4_CLANG_VERSION __apple_build_version__
 #       endif
 #   elif defined(__GNUC__)
+#       ifdef __MINGW32__
+#           define C4_MINGW
+#       endif
 #       define C4_GCC
 #       if defined(__GNUC_PATCHLEVEL__)
 #           define C4_GCC_VERSION C4_VERSION_ENCODED(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)


### PR DESCRIPTION
Thanks for providing such a very fast libraries!
In mingw64 compiler, there are compilation errors on rapidyaml 0.7.0:

```
In file included from src/c4/yml/tree.hpp:12,
                 from src/c4/yml/reference_resolver.hpp:4,
                 from src/c4/yml/reference_resolver.cpp:1:
src/c4/yml/common.hpp:14:10: fatal error: alloca.h: No such file or directory
   14 | #include <alloca.h>
      |          ^~~~~~~~~~
compilation terminated.
```
This is due to the lack of `alloca.h` in the mingw compiler as well as in the MSVC compiler.
I want to add `C4_MINGW` macro to c4core so that rapidyaml uses malloc.h instead of alloca.h on mingw.

```
#if defined(C4_MSVC) || defined(C4_MINGW)
#include <malloc.h>
#else
#include <alloca.h>
#endif
```

This same fix is also implemented in imgui.
https://github.com/ocornut/imgui/issues/276

