### PR TITLE
Add #include <cstddef> for std::ptrdiff_t usage

### DIFF
--- a/src/c4/enum.hpp
+++ b/src/c4/enum.hpp
@@ -2,6 +2,7 @@
 #define _C4_ENUM_HPP_
 
 #include "c4/error.hpp"
+#include <cstddef>
 #include <string.h>
 
 /** @file enum.hpp utilities for enums: convert to/from string


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/types/ptrdiff_t shows this is defined in <cstddef> but that header is not directly included in this file.