### PR TITLE
Specify default branch for git submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "cmake"]
 	path = cmake
 	url = https://github.com/biojppm/cmake
+	branch = master
 [submodule "extern/debugbreak"]
 	path = src/c4/ext/debugbreak
 	url = https://github.com/biojppm/debugbreak
+	branch = master
 [submodule "src/c4/ext/fast_float"]
 	path = src/c4/ext/fast_float
 	url = https://github.com/fastfloat/fast_float
+	branch = main


### PR DESCRIPTION
Missing default branches causes fails if the project is imported through CMake's `FetchContent` mechanism. It checks out the default branch and then switches to the pinned SHA. If the default branch is not specified, it assumes "origin/master", which doesn't always exist.

Here's the fail that I observe:
```
Submodule path 'ext/c4core/cmake': checked out 'e87e11f1a10af8aab4e0ceaade0bc7807f207eb1'
Submodule path 'ext/c4core/src/c4/ext/debugbreak': checked out '328e4abca3384cbd0a69e70f263cc7b2794bff09'
fatal: Needed a single revision
Unable to find current origin/master revision in submodule path 'src/c4/ext/fast_float'
```

The issue is reproduced only with relatively old git, for example with the one that come with Ubuntu 20.04.