### PR TITLE
Improvements: format and charconv

### DIFF
--- a/bm/CMakeLists.txt
+++ b/bm/CMakeLists.txt
@@ -31,7 +31,7 @@ c4_add_target_benchmark(c4core-bm-format catsepfile FILTER "^catsepfile_.*")
 c4_add_target_benchmark(c4core-bm-format formatfile FILTER "^formatfile_.*")
 
 if(C4CORE_BM_FMTLIB)
-    target_compile_definitions(c4core-bm-format PUBLIC -DC4CORE_BM_USE_FMTLIB)
+    target_compile_definitions(c4core-bm-format PUBLIC -DC4CORE_BM_FMTLIB)
 endif()
 
 
@@ -158,7 +158,7 @@ if(C4CORE_BM_ITOA_THREADS)
         FOLDER bm)
     target_compile_features(c4core-bm-itoa_threads PRIVATE cxx_std_20)
     if(C4CORE_BM_FMTLIB)
-        target_compile_definitions(c4core-bm-itoa_threads PUBLIC -DC4CORE_BM_USE_FMTLIB)
+        target_compile_definitions(c4core-bm-itoa_threads PUBLIC -DC4CORE_BM_FMTLIB)
     endif()
 
     unset(_c4core_itoa_thread_result_files)

--- a/bm/bm_atox.cpp
+++ b/bm/bm_atox.cpp
@@ -472,6 +472,7 @@ DEFINE_BM(int64_t)
 int main(int argc, char *argv[])
 {
     //do_test();
+    bm::MaybeReenterWithoutASLR(argc, argv);
     bm::Initialize(&argc, argv);
     bm::RunSpecifiedBenchmarks();
     return 0;

--- a/bm/bm_charconv.cpp
+++ b/bm/bm_charconv.cpp
@@ -1609,6 +1609,7 @@ C4BM_TEMPLATE(atox_sstream,   double);
 
 int main(int argc, char *argv[])
 {
+    bm::MaybeReenterWithoutASLR(argc, argv);
     bm::Initialize(&argc, argv);
     bm::RunSpecifiedBenchmarks();
     return 0;

--- a/bm/bm_format.cpp
+++ b/bm/bm_format.cpp
@@ -8,8 +8,11 @@
 #include <fstream>
 #include <cstdlib>
 #include <vector>
+#if C4_CPP >= 20
+#include <format>
+#endif
 
-#ifdef C4CORE_BM_USE_FMTLIB
+#ifdef C4CORE_BM_FMTLIB
 C4_SUPPRESS_WARNING_GCC_CLANG_PUSH
 C4_SUPPRESS_WARNING_GCC_CLANG("-Wfloat-equal")
 #define FMT_HEADER_ONLY
@@ -76,18 +79,18 @@ const c4::csubstr sep = " --- ";
 
 #define _c4argbundle_fmt "hello here you have some numbers: "\
     "1={}, 2={}, 3={}, 4={}, 5={}, 6={}, 7={}, 8={}, 9={}, size_t(283482349)={}, "\
-    "\" \"=\"{}\", \"haha\"=\"{}\", std::string(\"hehe\")=\"{}\", "\
-    "str=\"{}\""
+    "\" \"=\"{}\", \"haha\"=\"{}\", now std::string: "\
+    "s1=\"{}\", s2=\"{}\""
 
 #define _c4argbundle_fmt_printf "hello here you have some numbers: "\
     "1=%d, 2=%d, 3=%d, 4=%d, 5=%d, 6=%d, 7=%d, 8=%d, 9=%d, size_t(283482349)=%zu, "\
-    "\" \"=\"%s\", \"haha\"=\"%s\", std::string(\"hehe\")=\"%s\", "\
-    "str=\"%s\""
+    "\" \"=\"%s\", \"haha\"=\"%s\", now std::string: "\
+    "s1=\"%s\", s2=\"%s\""
 
 #define _c4argbundle_fmt_printf_sep "hello here you have some numbers: "\
     "1=%d%s2=%d%s3=%d%s4=%d%s5=%d%s6=%d%s7=%d%s8=%d%s9=%d%ssize_t(283482349)=%zu%s"\
-    "\" \"=\"%s\"%s\"haha\"=\"%s\"%sstd::string(\"hehe\")=\"%s\"%s"\
-    "str=\"%s\""
+    "\" \"=\"%s\"%s\"haha\"=\"%s\"%snow std::string: "\
+    "s1=\"%s\"%ss2=\"%s\""
 
 static const std::string s1_("hehe");
 static const std::string s2_("asdlklkasdlkjasd asdlkjasdlkjasdlkjasdoiasdlkjasldkjadsasdkjhasdkjhasdkjhasdkjhasdkjhsdfkjhsdfkjhsdfkjh");
@@ -111,6 +114,12 @@ static const std::string s2_("asdlklkasdlkjasd asdlkjasdlkjasdlkjasdoiasdlkjasld
 #define _c4argbundle_lshift_sep \
     1 << sep << 2 << sep << 3 << sep << 4 << sep << 5 << sep << 6 << sep << 7 << sep << 8 << sep << 9 << sep << size_t(283482349)\
       << sep << " " << sep << "haha" << sep << s1_ << sep << s2_
+
+#define _c4argbundle_lshift_fmt "hello here you have some numbers: "\
+    "1=" << 1 << ", 2=" << 2 << ", 3=" << 3 << ", 4=" << 4 << ", 5=" << 5 \
+    << ", 6=" << 6 << ", 7=" << 7 << ", 8=" << 8 << ", 9=" << 9 << ", size_t(283482349)=" << size_t(283482349) << ", " \
+    "\" \"=\"" << " " << "\", \"haha\"=\"" << "haha" << "\", now std::string: " \
+    "s1=\"" << s1_ << "\" s2=\"" << s2_ << "\""
 
 
 //-----------------------------------------------------------------------------
@@ -690,6 +699,20 @@ void catsepfile_ofstream(bm::State &st)
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
+#if C4_CPP >= 20
+void format_std_format_to_n(bm::State &st)
+{
+    char buf[512];
+    size_t sz = {};
+    for(auto _ : st)
+    {
+        auto ret = std::format_to_n(buf, sizeof(buf), _c4argbundle_fmt, _c4argbundle);
+        sz = (size_t)ret.size;
+    }
+    report(st, sz);
+}
+#endif
+
 void format_c4format(bm::State &st)
 {
     char buf_[512];
@@ -725,10 +748,9 @@ void format_c4formatrs_no_reuse(bm::State &st)
     report(st, sz);
 }
 
-#ifdef C4CORE_BM_USE_FMTLIB
+#ifdef C4CORE_BM_FMTLIB
 void format_fmtlib_format_to(bm::State &st)
 {
-    size_t sum = {};
 	fmt::memory_buffer buf;
     size_t sz = 0;
     for(auto _ : st)
@@ -736,9 +758,7 @@ void format_fmtlib_format_to(bm::State &st)
         buf.clear();
         fmt::format_to(fmt::appender(buf), _c4argbundle_fmt, _c4argbundle);
         sz = buf.size();
-        sum += sz + (size_t)buf[0];
     }
-    bm::DoNotOptimize(sum);
     report(st, sz);
 }
 #endif
@@ -804,6 +824,32 @@ void format_snprintf(bm::State &st)
     for(auto _ : st)
     {
         sz = (size_t) snprintf(buf.str, buf.len, _c4argbundle_fmt_printf, _c4argbundle_printf);
+    }
+    report(st, sz);
+}
+
+void format_stdsstream_reuse(bm::State &st)
+{
+    size_t sz = 0;
+    std::stringstream ss;
+    for(auto _ : st)
+    {
+        ss.clear();
+        ss.str("");
+        ss << _c4argbundle_lshift_fmt;
+        sz = ss.str().size();
+    }
+    report(st, sz);
+}
+
+void format_stdsstream_no_reuse(bm::State &st)
+{
+    size_t sz = 0;
+    for(auto _ : st)
+    {
+        std::stringstream ss;
+        ss << _c4argbundle_lshift_fmt;
+        sz = ss.str().size();
     }
     report(st, sz);
 }
@@ -924,11 +970,13 @@ C4BM(catsepfile_c4catsepdump_lambda_style);
 C4BM(catsepfile_fprintf);
 C4BM(catsepfile_ofstream);
 
-
+#if C4_CPP >= 20
+C4BM(format_std_format_to_n);
+#endif
 C4BM(format_c4format);
 C4BM(format_c4formatrs_reuse);
 C4BM(format_c4formatrs_no_reuse);
-#ifdef C4CORE_BM_USE_FMTLIB
+#ifdef C4CORE_BM_FMTLIB
 C4BM(format_fmtlib_format_to);
 #endif
 C4BM(format_c4formatdump_c_style_static_dispatch);
@@ -936,6 +984,8 @@ C4BM(format_c4formatdump_c_style_dynamic_dispatch);
 C4BM(format_c4formatdump_cpp_style);
 C4BM(format_c4formatdump_lambda_style);
 C4BM(format_snprintf);
+C4BM(format_stdsstream_reuse);
+C4BM(format_stdsstream_no_reuse);
 
 C4BM(formatfile_c4formatdump_c_style_static_dispatch);
 C4BM(formatfile_c4formatdump_c_style_dynamic_dispatch);
@@ -950,6 +1000,7 @@ C4BM(formatfile_fprintf);
 
 int main(int argc, char *argv[])
 {
+    bm::MaybeReenterWithoutASLR(argc, argv);
     bm::Initialize(&argc, argv);
     bm::RunSpecifiedBenchmarks();
     return 0;

--- a/bm/bm_itoa_threads.cpp
+++ b/bm/bm_itoa_threads.cpp
@@ -20,7 +20,7 @@ C4_SUPPRESS_WARNING_GCC_CLANG_PUSH
 C4_SUPPRESS_WARNING_GCC_CLANG("-Wcast-align")
 C4_SUPPRESS_WARNING_GCC("-Wuseless-cast")
 
-#ifdef C4CORE_BM_USE_FMTLIB
+#ifdef C4CORE_BM_FMTLIB
 C4_SUPPRESS_WARNING_GCC_CLANG_PUSH
 C4_SUPPRESS_WARNING_GCC_CLANG("-Wfloat-equal")
 #define FMT_HEADER_ONLY
@@ -222,7 +222,7 @@ BMTHREADS(std_format_to);
 
 
 
-#ifdef C4CORE_BM_USE_FMTLIB
+#ifdef C4CORE_BM_FMTLIB
 void fmtlib_format_to(bm::State &st)
 {
     size_t sum = {};

--- a/bm/bm_xtoa.cpp
+++ b/bm/bm_xtoa.cpp
@@ -1532,6 +1532,7 @@ void do_test()
 int main(int argc, char *argv[])
 {
     //do_test();
+    bm::MaybeReenterWithoutASLR(argc, argv);
     bm::Initialize(&argc, argv);
     bm::RunSpecifiedBenchmarks();
     return 0;

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,0 +1,12 @@
+[#162](https://github.com/biojppm/c4core/pull/162)
+  - charconv.hpp:
+    - minor simplification of `atoi_first()` and `atou_first()`
+    - add implementation of `to_chars()` for raw char pointers
+    - improve `from_chars()` for bool
+  - format.hpp:
+    - simplify `boolalpha()` implementation
+    - `catrs()`/`catseprs()`/`formatrs()`: resize to capacity before trying
+    - fix `uncatsep()`: force sep as a csubstr, and enforce it
+    - `cat()`/`catsep()`/`format(): add tests to ensure repeated args
+    - improve implementation of `fmt::left()`/`fmt::right()`. add `fmt::center()`
+  - Improve doxygen comments

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -792,36 +792,36 @@ size_t write_num_digits(substr buf, T v, size_t num_digits) noexcept
 /** @endcond */
 
 
-/** same as c4::write_dec(), but pad with zeroes on the left
- * such that the resulting string is @p num_digits wide.
- * If the given number is requires more than num_digits, then the number prevails. */
+/** same as c4::write_dec(), but pad with zeroes on the left such that
+ * the resulting string is @p num_digits wide.  If the given number
+ * requires more than num_digits, then the number prevails. */
 template<class T>
 C4_ALWAYS_INLINE size_t write_dec(substr buf, T val, size_t num_digits) noexcept
 {
     return detail::write_num_digits<T, &write_dec<T>>(buf, val, num_digits);
 }
 
-/** same as c4::write_hex(), but pad with zeroes on the left
- * such that the resulting string is @p num_digits wide.
- * If the given number is requires more than num_digits, then the number prevails. */
+/** same as c4::write_hex(), but pad with zeroes on the left such that
+ * the resulting string is @p num_digits wide.  If the given number
+ * requires more than num_digits, then the number prevails. */
 template<class T>
 C4_ALWAYS_INLINE size_t write_hex(substr buf, T val, size_t num_digits) noexcept
 {
     return detail::write_num_digits<T, &write_hex<T>>(buf, val, num_digits);
 }
 
-/** same as c4::write_bin(), but pad with zeroes on the left
- * such that the resulting string is @p num_digits wide.
- * If the given number is requires more than num_digits, then the number prevails. */
+/** same as c4::write_bin(), but pad with zeroes on the left such that
+ * the resulting string is @p num_digits wide.  If the given number
+ * requires more than num_digits, then the number prevails. */
 template<class T>
 C4_ALWAYS_INLINE size_t write_bin(substr buf, T val, size_t num_digits) noexcept
 {
     return detail::write_num_digits<T, &write_bin<T>>(buf, val, num_digits);
 }
 
-/** same as c4::write_oct(), but pad with zeroes on the left
- * such that the resulting string is @p num_digits wide.
- * If the given number is requires more than num_digits, then the number prevails. */
+/** same as c4::write_oct(), but pad with zeroes on the left such that
+ * the resulting string is @p num_digits wide.  If the given number
+ * requires more than num_digits, then the number prevails. */
 template<class T>
 C4_ALWAYS_INLINE size_t write_oct(substr buf, T val, size_t num_digits) noexcept
 {
@@ -2583,7 +2583,7 @@ inline size_t to_chars(substr buf, substr v) noexcept
 {
     C4_ASSERT(!buf.overlaps(v));
     size_t len = buf.len < v.len ? buf.len : v.len;
-    // calling memcpy with null strings is undefined behavior
+    // calling memcpy zero len is undefined behavior
     // and will wreak havoc in calling code's branches.
     // see https://github.com/biojppm/rapidyaml/pull/264#issuecomment-1262133637
     if(len)
@@ -2602,7 +2602,7 @@ inline bool from_chars(csubstr buf, substr * C4_RESTRICT v) noexcept
     // is the destination buffer wide enough?
     if(v->len >= buf.len)
     {
-        // calling memcpy with null strings is undefined behavior
+        // calling memcpy with zero len is undefined behavior
         // and will wreak havoc in calling code's branches.
         // see https://github.com/biojppm/rapidyaml/pull/264#issuecomment-1262133637
         if(buf.len)
@@ -2625,7 +2625,7 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
     if(C4_UNLIKELY(trimmed.len == 0))
         return csubstr::npos;
     size_t len = trimmed.len > v->len ? v->len : trimmed.len;
-    // calling memcpy with null strings is undefined behavior
+    // calling memcpy with zero len is undefined behavior
     // and will wreak havoc in calling code's branches.
     // see https://github.com/biojppm/rapidyaml/pull/264#issuecomment-1262133637
     if(len)
@@ -2642,7 +2642,8 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
 
 //-----------------------------------------------------------------------------
 
-/** @ingroup doc_to_chars */
+/** @ingroup doc_to_chars
+ * (1) overload for `char(&)[N]` and `const char(&)[N]` */
 template<size_t N>
 inline size_t to_chars(substr buf, const char (& C4_RESTRICT v)[N]) noexcept
 {

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -2454,37 +2454,36 @@ C4_ALWAYS_INLINE size_t to_chars(substr buf, bool v) noexcept
 /** @ingroup doc_from_chars */
 inline bool from_chars(csubstr buf, bool * C4_RESTRICT v) noexcept
 {
-    if(buf == '0')
+    if(buf.len == 1)
     {
-        *v = false; return true;
+        if(buf.str[0] == '0')
+        {
+            *v = false; return true;
+        }
+        else if(buf.str[0] == '1')
+        {
+            *v = true; return true;
+        }
     }
-    else if(buf == '1')
+    else if(buf.len == 4)
     {
-        *v = true; return true;
+        if(((buf.str[0] == 't') && (0 == memcmp(buf.str + 1, "rue", 3)))
+           ||
+           ((buf.str[0] == 'T') && ((0 == memcmp(buf.str + 1, "rue", 3) ||
+                                     0 == memcmp(buf.str + 1, "RUE", 3)))))
+        {
+            *v = true; return true;
+        }
     }
-    else if(buf == "false")
+    else if(buf.len == 5)
     {
-        *v = false; return true;
-    }
-    else if(buf == "true")
-    {
-        *v = true; return true;
-    }
-    else if(buf == "False")
-    {
-        *v = false; return true;
-    }
-    else if(buf == "True")
-    {
-        *v = true; return true;
-    }
-    else if(buf == "FALSE")
-    {
-        *v = false; return true;
-    }
-    else if(buf == "TRUE")
-    {
-        *v = true; return true;
+        if(((buf.str[0] == 'f') && (0 == memcmp(buf.str + 1, "alse", 4)))
+           ||
+           ((buf.str[0] == 'F') && ((0 == memcmp(buf.str + 1, "alse", 4) ||
+                                     0 == memcmp(buf.str + 1, "ALSE", 4)))))
+        {
+            *v = false; return true;
+        }
     }
     // fallback to c-style int bools
     int val = 0;

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -2342,7 +2342,13 @@ C4_ALWAYS_INLINE size_t to_chars(substr buf,   double v) noexcept { return dtoa(
 template <class T> C4_ALWAYS_INLINE auto to_chars(substr buf, T v) noexcept -> _C4_IF_NOT_FIXED_LENGTH_I(T, size_t)::type { return itoa(buf, v); }
 template <class T> C4_ALWAYS_INLINE auto to_chars(substr buf, T v) noexcept -> _C4_IF_NOT_FIXED_LENGTH_U(T, size_t)::type { return write_dec(buf, v); }
 template <class T>
-C4_ALWAYS_INLINE size_t to_chars(substr s, T *v) noexcept { return itoa(s, (intptr_t)v, (intptr_t)16); }
+C4_ALWAYS_INLINE auto to_chars(substr s, T *v) noexcept
+    -> typename std::enable_if<!std::is_same<T, char>::value &&
+                               !std::is_same<T, const char>::value,
+                               size_t>::type
+{
+    return itoa(s, (intptr_t)v, (intptr_t)16);
+}
 
 /** @} */
 
@@ -2645,16 +2651,24 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
 /** @ingroup doc_to_chars
  * (1) overload for `char(&)[N]` and `const char(&)[N]` */
 template<size_t N>
-inline size_t to_chars(substr buf, const char (& C4_RESTRICT v)[N]) noexcept
+size_t to_chars(substr buf, const char (& C4_RESTRICT v)[N]) noexcept
 {
-    csubstr sp(v);
-    return to_chars(buf, sp);
+    return to_chars(buf, csubstr{v, N-1});
 }
 
-/** @ingroup doc_to_chars */
-inline size_t to_chars(substr buf, const char * C4_RESTRICT v) noexcept
+/** @ingroup doc_to_chars
+ * (2) overload for `char*` and `const char*`. Must be zero-terminated!
+ * @warning will call strlen()
+ * @note this overload uses SFINAE to prevent it from overriding the array overload
+ * @see For a more detailed explanation on why the plain pointer overloads cannot
+ * coexist with the array overloads, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
+template<class CharPtr>
+auto to_chars(substr buf, CharPtr v) noexcept
+    -> typename std::enable_if<std::is_same<CharPtr, char*>::value
+                               ||
+                               std::is_same<CharPtr, const char*>::value, size_t>::type
 {
-    return to_chars(buf, to_csubstr(v));
+    return to_chars(buf, csubstr{v, strlen(v)});
 }
 
 /** @} */

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -1507,9 +1507,7 @@ template<class T>
 C4_ALWAYS_INLINE size_t atoi_first(csubstr str, T * C4_RESTRICT v)
 {
     csubstr trimmed = str.first_int_span();
-    if(trimmed.len == 0)
-        return csubstr::npos;
-    if(atoi(trimmed, v))
+    if(trimmed.len && atoi(trimmed, v))
         return static_cast<size_t>(trimmed.end() - str.begin());
     return csubstr::npos;
 }
@@ -1588,9 +1586,7 @@ template<class T>
 C4_ALWAYS_INLINE size_t atou_first(csubstr str, T *v)
 {
     csubstr trimmed = str.first_uint_span();
-    if(trimmed.len == 0)
-        return csubstr::npos;
-    if(atou(trimmed, v))
+    if(trimmed.len && atou(trimmed, v))
         return static_cast<size_t>(trimmed.end() - str.begin());
     return csubstr::npos;
 }

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -59,20 +59,17 @@ namespace fmt {
 /** @defgroup doc_boolean_specifiers boolean specifiers
  * @{ */
 
-/** write a variable as an alphabetic boolean, ie as either true or false
- * @param strict_read */
-template<class T>
 struct boolalpha_
 {
-    boolalpha_(T val_, bool strict_read_=false) : val(val_ ? true : false), strict_read(strict_read_) {}
     bool val;
-    bool strict_read;
 };
 
+/** tag function to mark a variable to be written as an alphabetic
+ * boolean, ie as either true or false */
 template<class T>
-boolalpha_<T> boolalpha(T const& val, bool strict_read=false)
+boolalpha_ boolalpha(T const& val=false)
 {
-    return boolalpha_<T>(val, strict_read);
+    return boolalpha_{val ? true : false};
 }
 
 /** @} */
@@ -84,8 +81,7 @@ boolalpha_<T> boolalpha(T const& val, bool strict_read=false)
 /** write a variable as an alphabetic boolean, ie as either true or
  * false
  * @ingroup doc_to_chars */
-template<class T>
-inline size_t to_chars(substr buf, fmt::boolalpha_<T> fmt)
+inline size_t to_chars(substr buf, fmt::boolalpha_ fmt)
 {
     return to_chars(buf, fmt.val ? "true" : "false");
 }

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -660,9 +660,9 @@ size_t cat(substr buf, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more
 
 /** like @ref c4::cat() but return a substr instead of a size */
 template<class... Args>
-substr cat_sub(substr buf, Args && ...args)
+substr cat_sub(substr buf, Args const& C4_RESTRICT ...args)
 {
-    size_t sz = cat(buf, std::forward<Args>(args)...);
+    size_t sz = cat(buf, args...);
     C4_CHECK(sz <= buf.len);
     return {buf.str, sz <= buf.len ? sz : buf.len};
 }
@@ -958,10 +958,10 @@ inline size_t format(substr buf, csubstr fmt)
 template<class Arg, class... Args>
 size_t format(substr buf, csubstr fmt, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more)
 {
-    size_t pos = fmt.find("{}"); // @todo use _find_fmt()
+    size_t pos = fmt.find("{}");
     if(C4_UNLIKELY(pos == csubstr::npos))
         return to_chars(buf, fmt);
-    size_t num = to_chars(buf, fmt.sub(0, pos));
+    size_t num = to_chars(buf, fmt.first(pos));
     size_t out = num;
     buf  = buf.len >= num ? buf.sub(num) : substr{};
     num  = to_chars(buf, a);

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -574,6 +574,7 @@ size_t to_chars(substr buf, fmt::right_<T> const& C4_RESTRICT align)
 /** @defgroup doc_cat cat: concatenate arguments to string
  * @{ */
 
+
 /** @cond dev */
 // terminates the variadic recursion
 inline size_t cat(substr /*buf*/)
@@ -586,10 +587,28 @@ inline size_t cat(substr /*buf*/)
 /** serialize the arguments, concatenating them to the given fixed-size buffer.
  * The buffer size is strictly respected: no writes will occur beyond its end.
  * @return the number of characters needed to write all the arguments into the buffer.
- * @see c4::catrs() if instead of a fixed-size buffer, a resizeable container is desired
- * @see c4::uncat() for the inverse function
- * @see c4::catsep() if a separator between each argument is to be used
- * @see c4::format() if a format string is desired */
+ * @see @ref c4::catrs() if instead of a fixed-size buffer, a resizeable container is desired
+ * @see @ref c4::uncat() for the inverse function
+ * @see @ref c4::catsep() if a separator between each argument is to be used
+ * @see @ref c4::format() if a format string is desired
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class Arg, class... Args>
 size_t cat(substr buf, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more)
 {
@@ -599,7 +618,7 @@ size_t cat(substr buf, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more
     return num;
 }
 
-/** like c4::cat() but return a substr instead of a size */
+/** like @ref c4::cat() but return a substr instead of a size */
 template<class... Args>
 substr cat_sub(substr buf, Args && ...args)
 {
@@ -630,7 +649,7 @@ inline size_t uncat(csubstr /*buf*/)
  *
  * @return the number of characters read from the buffer, or csubstr::npos
  *   if a conversion was not successful.
- * @see c4::cat(). c4::uncat() is the inverse of c4::cat(). */
+ * @see @ref c4::cat(). @ref c4::uncat() is the inverse of @ref c4::cat(). */
 template<class Arg, class... Args>
 size_t uncat(csubstr buf, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
@@ -707,6 +726,7 @@ size_t uncatsep_more(csubstr buf, Sep & C4_RESTRICT sep, Arg & C4_RESTRICT a, Ar
 
 } // namespace detail
 
+// terminates the variadic recursion
 template<class Sep>
 size_t catsep(substr /*buf*/, Sep const& C4_RESTRICT /*sep*/)
 {
@@ -719,10 +739,29 @@ size_t catsep(substr /*buf*/, Sep const& C4_RESTRICT /*sep*/)
  * buffer, using a separator between each argument.
  * The buffer size is strictly respected: no writes will occur beyond its end.
  * @return the number of characters needed to write all the arguments into the buffer.
- * @see c4::catseprs() if instead of a fixed-size buffer, a resizeable container is desired
- * @see c4::uncatsep() for the inverse function (ie, reading instead of writing)
- * @see c4::cat() if no separator is needed
- * @see c4::format() if a format string is desired */
+ * @see @ref c4::catseprs() if instead of a fixed-size buffer, a resizeable container is desired
+ * @see @ref c4::uncatsep() for the inverse function (ie, reading instead of writing)
+ * @see @ref c4::cat() if no separator is needed
+ * @see @ref c4::format() if a format string is desired
+ *
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class Sep, class Arg, class... Args>
 size_t catsep(substr buf, Sep const& C4_RESTRICT sep, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more)
 {
@@ -732,8 +771,9 @@ size_t catsep(substr buf, Sep const& C4_RESTRICT sep, Arg const& C4_RESTRICT a, 
     return num;
 }
 
-/** like c4::catsep() but return a substr instead of a size
- * @see c4::catsep(). c4::uncatsep() is the inverse of c4::catsep(). */
+/** like @ref c4::catsep() but return a substr instead of a size @see
+ * @ref c4::catsep(). @ref c4::uncatsep() is the inverse of @ref
+ * c4::catsep(). */
 template<class... Args>
 substr catsep_sub(substr buf, Args && ...args)
 {
@@ -797,21 +837,84 @@ inline size_t format(substr buf, csubstr fmt)
 /// @endcond
 
 
-/** using a format string, serialize the arguments into the given
- * fixed-size buffer.
- * The buffer size is strictly respected: no writes will occur beyond its end.
- * In the format string, each argument is marked with a compact
- * curly-bracket pair: {}. Arguments beyond the last curly bracket pair
- * are silently ignored. For example:
+/** Using a format string, serialize the arguments into the given
+ * fixed-size buffer. The buffer size is strictly respected: no writes
+ * will occur beyond its end. In the format string, each argument is
+ * marked with a compact curly-bracket pair "{}". This pair does not
+ * take any interior sequence numbers or extra formatting arguments
+ * inside it (contrary to eg the C++20 std::format implementation or
+ * the Python formatting facilities). To enable argument
+ * customization, use the formatting facilities in @ref
+ * doc_format_specifiers wrapping the arguments passed to this
+ * function.
+ *
+ * @return the number of bytes needed to write into the buffer.
+ *
+ * @see @ref c4::formatrs() if instead of a fixed-size buffer, a resizeable container is desired
+ * @see @ref c4::unformat() for the inverse function
+ * @see @ref c4::cat() if no format or separator is needed
+ * @see @ref c4::catsep() if no format is needed, but a separator must be used
+ *
+ * For example:
  * @code{.cpp}
  * c4::format(buf, "the {} drank {} {}", "partier", 5, "beers"); // the partier drank 5 beers
  * c4::format(buf, "the {} drank {} {}", "programmer", 6, "coffees"); // the programmer drank 6 coffees
  * @endcode
- * @return the number of characters needed to write into the buffer.
- * @see c4::formatrs() if instead of a fixed-size buffer, a resizeable container is desired
- * @see c4::unformat() for the inverse function
- * @see c4::cat() if no format or separator is needed
- * @see c4::catsep() if no format is needed, but a separator must be used */
+ *
+ * Using @ref
+ * doc_format_specifiers enables control of the result. For example:
+ * @code{.cpp}
+ * c4::format(buf, "the {} drank {} {}", "partier", c4::fmt::real(5, 3), "beers"); // the partier drank 5.000 beers
+ * c4::format(buf, "the {} drank {} {}", "partier", c4::fmt::zpad(5, 3), "beers"); // the partier drank 005 beers
+ * c4::format(buf, "the {} drank {} {}", "partier", c4::fmt::bin(5), "beers"); // the partier drank 0b101 beers
+ * c4::format(buf, "the {} drank {} {}", "partier", c4::fmt::oct(5), "beers"); // the partier drank 0o6 beers
+ * c4::format(buf, "the {} drank {} {}", "partier", c4::fmt::hex(5), "beers"); // the partier drank 0x6 beers
+ * c4::format(buf, "the {} drank {} {}", "programmer", c4::fmt::real(6, 3), "coffees"); // the programmer drank 6.000 coffees
+ * c4::format(buf, "the {} drank {} {}", "programmer", c4::fmt::zpad(6, 3), "coffees"); // the programmer drank 006 coffees
+ * c4::format(buf, "the {} drank {} {}", "programmer", c4::fmt::bin(6), "coffees"); // the programmer drank 0b110 coffees
+ * c4::format(buf, "the {} drank {} {}", "programmer", c4::fmt::oct(6), "coffees"); // the programmer drank 0o6 coffees
+ * c4::format(buf, "the {} drank {} {}", "programmer", c4::fmt::hex(6), "coffees"); // the programmer drank 0x6 coffees
+ * @endcode
+ *
+ * @note Arguments beyond the last curly bracket pair are silently
+ * ignored. Curly bracket pairs without a corresponding argument are
+ * printed as part of the result.
+ * @code{.cpp}
+ * // note "and nothing else" being ignored
+ * c4::format(buf, "the {} drank {} {}", "partier", 5, "beers", "and nothing else"); // the partier drank 5 beers
+ *
+ * // note "this is ignored {}" being part of the result
+ * c4::format(buf, "the {} drank {} {} this is ignored: {}", "programmer", 6, "coffees"); // the programmer drank 6 coffees this is ignored: {}
+ * @endcode
+ *
+ * @note The curly bracket pair cannot be escaped, but can of course
+ * be placed into the result by passing an "{}" argument in its place,
+ * or if it is provided beyond the last argument passed to the
+ * function (see prior note).
+ * @code{.cpp}
+ * // as above: no argument given, so no substitution made:
+ * c4::format(buf, "let's show {} on the result"); // let's show {} on the result
+ * // or just pass "{}" as an argument to force the substitution:
+ * c4::format(buf, "let's show {} on the result and then {}", "{}", "this"); // let's show {} on the result and then this
+ * @endcode
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class Arg, class... Args>
 size_t format(substr buf, csubstr fmt, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more)
 {
@@ -829,9 +932,9 @@ size_t format(substr buf, csubstr fmt, Arg const& C4_RESTRICT a, Args const& C4_
     return out;
 }
 
-/** like c4::format() but return a substr instead of a size
+/** like @ref c4::format() but return a substr instead of a size
  * @see c4::format()
- * @see c4::catsep(). uncatsep() is the inverse of catsep(). */
+ * @see c4::catsep(). @ref c4::uncatsep() is the inverse of @ref c4::catsep(). */
 template<class... Args>
 substr format_sub(substr buf, csubstr fmt, Args const& C4_RESTRICT ...args)
 {
@@ -858,9 +961,11 @@ inline size_t unformat(csubstr /*buf*/, csubstr fmt)
 
 
 /** using a format string, deserialize the arguments from the given
- * buffer.
+ * buffer. This is the inverse function to @ref c4::format().
+ *
  * @return the number of characters read from the buffer, or npos if a conversion failed.
- * @see c4::format(). c4::unformat() is the inverse function to format(). */
+ *
+ * @see @ref c4::format(). */
 template<class Arg, class... Args>
 size_t unformat(csubstr buf, csubstr fmt, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
@@ -889,11 +994,31 @@ size_t unformat(csubstr buf, csubstr fmt, Arg & C4_RESTRICT a, Args & C4_RESTRIC
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
-/** cat+resize: like c4::cat(), but receives a container, and resizes
- * it as needed to contain the result. The container is
- * overwritten. To append to it, use the append overload.
- * @see c4::cat()
- * @ingroup doc_cat */
+/** cat+resize: like @ref c4::cat(), but receives a container, and
+ * resizes it as needed to contain the result. The container is
+ * overwritten. To append to it, use @ref c4::catrs_append().
+ *
+ * @see @ref c4::cat()
+ * @see @ref c4::catrs_append()
+ * @ingroup doc_cat
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class... Args>
 inline void catrs(CharOwningContainer * C4_RESTRICT cont, Args const& C4_RESTRICT ...args)
 {
@@ -905,10 +1030,29 @@ retry:
         goto retry;
 }
 
-/** cat+resize: like c4::cat(), but creates and returns a new
+/** cat+resize: like @ref c4::cat(), but creates and returns a new
  * container sized as needed to contain the result.
- * @see c4::cat()
- * @ingroup doc_cat */
+ *
+ * @see @ref c4::cat()
+ * @ingroup doc_cat
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class... Args>
 inline CharOwningContainer catrs(Args const& C4_RESTRICT ...args)
 {
@@ -917,14 +1061,32 @@ inline CharOwningContainer catrs(Args const& C4_RESTRICT ...args)
     return cont;
 }
 
-/** cat+resize+append: like c4::cat(), but receives a container, and
- * appends to it instead of overwriting it. The container is resized
- * as needed to contain the result.
+/** cat+resize+append: like @ref c4::cat(), but receives a container,
+ * and appends to it instead of overwriting it. The container is
+ * resized as needed to contain the result.
  *
  * @return the region newly appended to the original container
- * @see c4::cat()
- * @see c4::catrs()
- * @ingroup doc_cat */
+ * @see @ref c4::cat()
+ * @see @ref c4::catrs()
+ * @ingroup doc_cat
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class... Args>
 inline csubstr catrs_append(CharOwningContainer * C4_RESTRICT cont, Args const& C4_RESTRICT ...args)
 {
@@ -941,12 +1103,32 @@ retry:
 
 //-----------------------------------------------------------------------------
 
-/** catsep+resize: like c4::catsep(), but receives a container, and
- * resizes it as needed to contain the result.  The container is
- * overwritten. To append to the container use the append overload.
+/** catsep+resize: like @ref c4::catsep(), but receives a container,
+ * and resizes it as needed to contain the result.  The container is
+ * overwritten. To append to the container use @ref
+ * c4::catseprs_append().
  *
- * @see c4::catsep()
- * @ingroup doc_catsep */
+ * @see @ref c4::catsep()
+ * @see @ref c4::catseprs_append()
+ * @ingroup doc_catsep
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class Sep, class... Args>
 inline void catseprs(CharOwningContainer * C4_RESTRICT cont, Sep const& C4_RESTRICT sep, Args const& C4_RESTRICT ...args)
 {
@@ -958,11 +1140,29 @@ retry:
         goto retry;
 }
 
-/** catsep+resize: like c4::catsep(), but create a new container with
- * the result.
+/** catsep+resize: like @ref c4::catsep(), but create a new container
+ * with the result.
  *
  * @return the requested container
- * @ingroup doc_catsep */
+ * @ingroup doc_catsep
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class Sep, class... Args>
 inline CharOwningContainer catseprs(Sep const& C4_RESTRICT sep, Args const& C4_RESTRICT ...args)
 {
@@ -972,12 +1172,30 @@ inline CharOwningContainer catseprs(Sep const& C4_RESTRICT sep, Args const& C4_R
 }
 
 
-/** catsep+resize+append: like catsep(), but receives a container, and
- * appends the arguments, resizing the container as needed to contain
- * the result. The buffer is appended to.
+/** catsep+resize+append: like @ref c4::catsep(), but receives a
+ * container, and appends the arguments, resizing the container as
+ * needed to contain the result. The buffer is appended to.
  *
  * @return a csubstr of the appended part
- * @ingroup doc_catsep */
+ * @ingroup doc_catsep
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class Sep, class... Args>
 inline csubstr catseprs_append(CharOwningContainer * C4_RESTRICT cont, Sep const& C4_RESTRICT sep, Args const& C4_RESTRICT ...args)
 {
@@ -994,12 +1212,32 @@ retry:
 
 //-----------------------------------------------------------------------------
 
-/** format+resize: like c4::format(), but receives a container, and
- * resizes it as needed to contain the result.  The container is
- * overwritten. To append to the container use the append overload.
+/** format+resize: like @ref c4::format(), but receives a container,
+ * and resizes it as needed to contain the result.  The container is
+ * overwritten. To append to the container use @ref
+ * c4::formatrs_append().
  *
- * @see c4::format()
- * @ingroup doc_format */
+ * @see @ref c4::format()
+ * @see @ref c4::formatrs_append()
+ * @ingroup doc_format
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class... Args>
 inline void formatrs(CharOwningContainer * C4_RESTRICT cont, csubstr fmt, Args const& C4_RESTRICT ...args)
 {
@@ -1011,11 +1249,29 @@ retry:
         goto retry;
 }
 
-/** format+resize: like c4::format(), but create a new container with
- * the result.
+/** format+resize: like @ref c4::format(), but create a new container
+ * with the result.
  *
  * @return the requested container
- * @ingroup doc_format */
+ * @ingroup doc_format
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class... Args>
 inline CharOwningContainer formatrs(csubstr fmt, Args const& C4_RESTRICT ...args)
 {
@@ -1024,11 +1280,30 @@ inline CharOwningContainer formatrs(csubstr fmt, Args const& C4_RESTRICT ...args
     return cont;
 }
 
-/** format+resize+append: like format(), but receives a container, and appends the
- * arguments, resizing the container as needed to contain the
- * result. The buffer is appended to.
+/** format+resize+append: like @ref c4::format(), but receives a
+ * container, and appends the arguments, resizing the container as
+ * needed to contain the result. The buffer is appended to.
+ *
  * @return the region newly appended to the original container
- * @ingroup doc_format */
+ * @ingroup doc_format
+ *
+ * @note The arguments to format are restricted (legal because they
+ * are rvalues). This may require a workaround when arguments of type
+ * char[]/const char[] are passed repeatedly to the function. For
+ * example,
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * cat(buf, str, str, str); // compile error: 'passing argument 2 to ‘restrict’-qualified parameter aliases with arguments 3, 4'
+ * @endcode
+ * It is possible to work around the problem by suppressing -Wrestrict
+ * or by using the decayed type char* or const char*, or even wrapping
+ * the argument in a csubstr():
+ * @code{.cpp}
+ * const char str[] = "Hi! ";
+ * csubstr ss = to_csubstr(str);
+ * cat(buf, ss, ss, ss); // ok! compiles cleanly
+ * @endcode
+ */
 template<class CharOwningContainer, class... Args>
 inline csubstr formatrs_append(CharOwningContainer * C4_RESTRICT cont, csubstr fmt, Args const& C4_RESTRICT ...args)
 {

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -488,7 +488,7 @@ inline size_t from_chars_first(csubstr buf, fmt::raw_wrapper r)
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-// formatting aligned to left/right
+// formatting aligned to left/right/center
 
 namespace fmt {
 
@@ -498,32 +498,61 @@ namespace fmt {
 /** @defgroup doc_alignment_specifiers Alignment specifiers
  * @{ */
 
-template<class T>
-struct left_
-{
-    T val;
-    size_t width;
-    char pad;
-    left_(T v, size_t w, char p) : val(v), width(w), pad(p) {}
-};
+template<class T> struct left_   { T val; size_t width; char padchar; C4_ALWAYS_INLINE left_  (T v, size_t w, char c) noexcept : val(v), width(w), padchar(c) {} };
+template<class T> struct center_ { T val; size_t width; char padchar; C4_ALWAYS_INLINE center_(T v, size_t w, char c) noexcept : val(v), width(w), padchar(c) {} };
+template<class T> struct right_  { T val; size_t width; char padchar; C4_ALWAYS_INLINE right_ (T v, size_t w, char c) noexcept : val(v), width(w), padchar(c) {} };
 
-template<class T>
-struct right_
-{
-    T val;
-    size_t width;
-    char pad;
-    right_(T v, size_t w, char p) : val(v), width(w), pad(p) {}
-};
-
-/** mark an argument to be aligned left */
+/** tag type to mark an argument to be aligned left.
+ * @param val the argument to be aligned left
+ * @param width the length of the field
+ * @param padchar the padding character, defaults to ' '
+ *
+ * @note This function (and the return structure) uses value semantics. To
+ * avoid copies on larger types, you can use std::cref(). For example:
+ * @code{.cpp}
+ * char buf[512];
+ * std::string large_string = .....;
+ * size_t len = cat(buf, fmt::left(std::cref(large_string), 100));
+ * @endcode
+ */
 template<class T>
 left_<T> left(T val, size_t width, char padchar=' ')
 {
     return left_<T>(val, width, padchar);
 }
 
-/** mark an argument to be aligned right */
+/** tag function to mark an argument to be aligned center
+ * @param val the argument to be aligned center
+ * @param width the length of the field
+ * @param padchar the padding character, defaults to ' '
+ *
+ * @note This function (and the return value) uses value semantics. To
+ * avoid copies on larger types, you can use std::cref(). For example:
+ * @code{.cpp}
+ * char buf[512];
+ * std::string large_string = .....;
+ * size_t len = cat(buf, fmt::center(std::cref(large_string), 100));
+ * @endcode
+ */
+template<class T>
+center_<T> center(T val, size_t width, char padchar=' ')
+{
+    return center_<T>(val, width, padchar);
+}
+
+/** tag function to mark an argument to be aligned right
+ * @param val the argument to be aligned right
+ * @param width the length of the field
+ * @param padchar the padding character, defaults to ' '
+ *
+ * @note This function (and the return value) uses value semantics. To
+ * avoid copies on larger types, you can use std::cref(). For example:
+ * @code{.cpp}
+ * char buf[512];
+ * std::string large_string = .....;
+ * size_t len = cat(buf, fmt::right(std::cref(large_string), 100));
+ * @endcode
+ */
 template<class T>
 right_<T> right(T val, size_t width, char padchar=' ')
 {
@@ -544,8 +573,7 @@ size_t to_chars(substr buf, fmt::left_<T> const& C4_RESTRICT align)
     size_t ret = to_chars(buf, align.val);
     if(ret >= buf.len || ret >= align.width)
         return ret > align.width ? ret : align.width;
-    buf.first(align.width).sub(ret).fill(align.pad);
-    to_chars(buf, align.val);
+    buf.first(align.width).sub(ret).fill(align.padchar);
     return align.width;
 }
 
@@ -556,9 +584,25 @@ size_t to_chars(substr buf, fmt::right_<T> const& C4_RESTRICT align)
     size_t ret = to_chars(buf, align.val);
     if(ret >= buf.len || ret >= align.width)
         return ret > align.width ? ret : align.width;
-    size_t rem = static_cast<size_t>(align.width - ret);
-    buf.first(rem).fill(align.pad);
-    to_chars(buf.sub(rem), align.val);
+    size_t rem = align.width - ret;
+    if(ret)
+        memmove(buf.str + rem, buf.str, ret);
+    buf.first(rem).fill(align.padchar);
+    return align.width;
+}
+
+/** @ingroup doc_to_chars */
+template<class T>
+size_t to_chars(substr buf, fmt::center_<T> const& C4_RESTRICT align)
+{
+    size_t ret = to_chars(buf, align.val);
+    if(ret >= buf.len || ret >= align.width)
+        return ret > align.width ? ret : align.width;
+    size_t first = (align.width - ret) / 2u;
+    if(ret)
+        memmove(buf.str + first, buf.str, ret);
+    buf.first(first).fill(align.padchar);
+    buf.sub(first + ret).fill(align.padchar);
     return align.width;
 }
 

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -1043,6 +1043,7 @@ size_t unformat(csubstr buf, csubstr fmt, Arg & C4_RESTRICT a, Args & C4_RESTRIC
 template<class CharOwningContainer, class... Args>
 inline void catrs(CharOwningContainer * C4_RESTRICT cont, Args const& C4_RESTRICT ...args)
 {
+    cont->resize(cont->capacity()); // improve the odds of fitting in the original buffer
 retry:
     substr buf = to_substr(*cont);
     size_t ret = cat(buf, args...);
@@ -1112,6 +1113,7 @@ template<class CharOwningContainer, class... Args>
 inline csubstr catrs_append(CharOwningContainer * C4_RESTRICT cont, Args const& C4_RESTRICT ...args)
 {
     const size_t pos = cont->size();
+    cont->resize(cont->capacity()); // improve the odds of fitting in the original buffer
 retry:
     substr buf = to_substr(*cont).sub(pos);
     size_t ret = cat(buf, args...);
@@ -1153,6 +1155,7 @@ retry:
 template<class CharOwningContainer, class Sep, class... Args>
 inline void catseprs(CharOwningContainer * C4_RESTRICT cont, Sep const& C4_RESTRICT sep, Args const& C4_RESTRICT ...args)
 {
+    cont->resize(cont->capacity()); // improve the odds of fitting in the original buffer
 retry:
     substr buf = to_substr(*cont);
     size_t ret = catsep(buf, sep, args...);
@@ -1221,6 +1224,7 @@ template<class CharOwningContainer, class Sep, class... Args>
 inline csubstr catseprs_append(CharOwningContainer * C4_RESTRICT cont, Sep const& C4_RESTRICT sep, Args const& C4_RESTRICT ...args)
 {
     const size_t pos = cont->size();
+    cont->resize(cont->capacity()); // improve the odds of fitting in the original buffer
 retry:
     substr buf = to_substr(*cont).sub(pos);
     size_t ret = catsep(buf, sep, args...);
@@ -1262,6 +1266,7 @@ retry:
 template<class CharOwningContainer, class... Args>
 inline void formatrs(CharOwningContainer * C4_RESTRICT cont, csubstr fmt, Args const& C4_RESTRICT ...args)
 {
+    cont->resize(cont->capacity()); // improve the odds of fitting in the original buffer
 retry:
     substr buf = to_substr(*cont);
     size_t ret = format(buf, fmt, args...);
@@ -1329,6 +1334,7 @@ template<class CharOwningContainer, class... Args>
 inline csubstr formatrs_append(CharOwningContainer * C4_RESTRICT cont, csubstr fmt, Args const& C4_RESTRICT ...args)
 {
     const size_t pos = cont->size();
+    cont->resize(cont->capacity()); // improve the odds of fitting in the original buffer
 retry:
     substr buf = to_substr(*cont).sub(pos);
     size_t ret = format(buf, fmt, args...);

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -736,34 +736,6 @@ size_t catsep_more(substr buf, Sep const& C4_RESTRICT sep, Arg const& C4_RESTRIC
     num += ret;
     return num;
 }
-
-
-template<class Sep>
-inline size_t uncatsep_more(csubstr /*buf*/, Sep & /*sep*/)
-{
-    return 0;
-}
-
-template<class Sep, class Arg, class... Args>
-size_t uncatsep_more(csubstr buf, Sep & C4_RESTRICT sep, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
-{
-    size_t ret = from_chars_first(buf, &sep);
-    size_t num = ret;
-    if(C4_UNLIKELY(ret == csubstr::npos))
-        return csubstr::npos;
-    buf  = buf.len >= ret ? buf.sub(ret) : substr{};
-    ret  = from_chars_first(buf, &a);
-    if(C4_UNLIKELY(ret == csubstr::npos))
-        return csubstr::npos;
-    num += ret;
-    buf  = buf.len >= ret ? buf.sub(ret) : substr{};
-    ret  = uncatsep_more(buf, sep, more...);
-    if(C4_UNLIKELY(ret == csubstr::npos))
-        return csubstr::npos;
-    num += ret;
-    return num;
-}
-
 } // namespace detail
 
 // terminates the variadic recursion
@@ -833,29 +805,38 @@ substr catsep_sub(substr buf, Args && ...args)
 /** @defgroup doc_uncatsep uncatsep: deserialize the separated arguments from a string
  * @{ */
 
-/** deserialize the arguments from the given buffer.
- *
- * @return the number of characters read from the buffer, or csubstr::npos
- *   if a conversion was not successful.
- * @see c4::cat(). c4::uncat() is the inverse of c4::cat(). */
+/** @cond dev */
+template<class Arg>
+inline size_t uncatsep(csubstr buf, csubstr /*sep*/, Arg &C4_RESTRICT a)
+{
+    return from_chars(buf, &a) ? buf.len : csubstr::npos;
+}
+/** @endcond */
 
 /** deserialize the arguments from the given buffer, using a separator.
  *
  * @return the number of characters read from the buffer, or csubstr::npos
  *   if a conversion was not successful
- * @see c4::catsep(). c4::uncatsep() is the inverse of c4::catsep(). */
-template<class Sep, class Arg, class... Args>
-size_t uncatsep(csubstr buf, Sep & C4_RESTRICT sep, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
+ *
+ * @see c4::catsep(). @ref c4::uncatsep() is the inverse of @ref c4::catsep(). */
+template<class Arg, class... Args>
+size_t uncatsep(csubstr buf, csubstr sep, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
-    size_t ret = from_chars_first(buf, &a), num = ret;
-    if(C4_UNLIKELY(ret == csubstr::npos))
-        return csubstr::npos;
-    buf  = buf.len >= ret ? buf.sub(ret) : substr{};
-    ret  = detail::uncatsep_more(buf, sep, more...);
-    if(C4_UNLIKELY(ret == csubstr::npos))
-        return csubstr::npos;
-    num += ret;
-    return num;
+    if(C4_LIKELY(sep.len > 0))
+    {
+        size_t pos = buf.find(sep);
+        if(C4_LIKELY(pos != csubstr::npos))
+        {
+            if(C4_LIKELY(from_chars(buf.first(pos), &a)))
+            {
+                pos += sep.len;
+                size_t num = uncatsep(buf.sub(pos), sep, more...);
+                if(C4_LIKELY(num != csubstr::npos))
+                    return pos + num;
+            }
+        }
+    }
+    return csubstr::npos;
 }
 
 /** @} */

--- a/src/c4/substr.hpp
+++ b/src/c4/substr.hpp
@@ -164,12 +164,12 @@ public:
      * @warning the end pointer MUST BE larger than or equal to the begin pointer
      * @warning the input string need not be zero terminated. */
     C4_ALWAYS_INLINE void assign(C *beg_, C *end_) noexcept { C4_ASSERT(end_ >= beg_); str = (beg_); len = static_cast<size_t>(end_ - beg_); }
-    /** Assign from a C-string (zero-terminated string)
+    /** Assign from a C-string (zero-terminated string of type const C* or C*)
      * @warning the input string must be zero terminated.
      * @warning will call strlen()
      * @note this overload uses SFINAE to prevent it from overriding the array ctor
-     * @see For a more detailed explanation on why the plain overloads cannot
-     * coexist, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
+     * @see For a more detailed explanation on why the plain pointer overloads cannot
+     * coexist with the array overloads, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
     template<class U, typename std::enable_if<std::is_same<U, C*>::value || std::is_same<U, NCC_*>::value, int>::type=0>
     C4_ALWAYS_INLINE void assign(U s_) noexcept { str = (s_); len = (s_ ? strlen(s_) : 0); }
 
@@ -177,12 +177,12 @@ public:
      * @warning the input string need not be zero terminated. */
     template<size_t N>
     C4_ALWAYS_INLINE basic_substring& operator= (C (&s_)[N]) noexcept { str = (s_); len = (N-1); return *this; }
-    /** Assign from a C-string (zero-terminated string)
+    /** Assign from a C-string (zero-terminated string of type const C* or C*)
      * @warning the input string MUST BE zero terminated.
      * @warning will call strlen()
      * @note this overload uses SFINAE to prevent it from overriding the array ctor
-     * @see For a more detailed explanation on why the plain overloads cannot
-     * coexist, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
+     * @see For a more detailed explanation on why the plain pointer overloads cannot
+     * coexist with the array overloads, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
     template<class U, typename std::enable_if<std::is_same<U, C*>::value || std::is_same<U, NCC_*>::value, int>::type=0>
     C4_ALWAYS_INLINE basic_substring& operator= (U s_) noexcept { str = s_; len = s_ ? strlen(s_) : 0; return *this; }
 

--- a/test/test_charconv.cpp
+++ b/test/test_charconv.cpp
@@ -2456,6 +2456,59 @@ TEST_CASE("to_chars.std_string")
     CHECK_EQ(buf.first(3), "foo");
 }
 
+template<class T, size_t N>
+void test_to_chars__char_arr(T (&arr)[N])
+{
+    INFO(arr);
+    char buf_[32];
+    substr buf(buf_);
+    size_t num = to_chars(buf, (T(&)[N])arr);
+    size_t expected_len = strlen(arr);
+    CHECK_EQ(num, expected_len);
+    REQUIRE_LE(num, buf.len);
+    csubstr expected = to_csubstr(arr);
+    csubstr actual = buf.first(num);
+    CHECK_EQ(actual, expected);
+}
+template<class T>
+void test_to_chars__char_ptr(T ptr)
+{
+    INFO(ptr);
+    char buf_[32];
+    substr buf(buf_);
+    size_t num = to_chars(buf, ptr);
+    size_t expected_len = strlen(ptr);
+    CHECK_EQ(num, expected_len);
+    REQUIRE_LE(num, buf.len);
+    csubstr expected = to_csubstr(ptr);
+    csubstr actual = buf.first(num);
+    CHECK_EQ(actual, expected);
+}
+template<size_t N>
+void test_to_chars__char_(char (&arr)[N])
+{
+    test_to_chars__char_arr((      char (&)[N])arr);
+    test_to_chars__char_arr((const char (&)[N])arr);
+    test_to_chars__char_ptr((      char*)arr);
+    test_to_chars__char_ptr((const char*)arr);
+}
+#define test_to_chars__char(str)                \
+    {                                           \
+        char arr[] = str;                       \
+        INFO("here:\n"                          \
+             << __FILE__ << ":" << __LINE__     \
+             << ": '" << arr << "'");           \
+        test_to_chars__char_(arr);              \
+    }
+TEST_CASE("to_chars.char")
+{
+    test_to_chars__char("0123");
+    test_to_chars__char("aslkjasdlkjasde");
+    test_to_chars__char("");
+    test_to_chars__char("a");
+    test_to_chars__char("ab");
+}
+
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -629,6 +629,85 @@ TEST_CASE("cat.tuple")
 }
 #endif // C4_TUPLE_TO_STR
 
+
+//-----------------------------------------------------------------------------
+
+template<class T>
+void test_cat_samevar5(T & v, csubstr expected)
+{
+    C4_SUPPRESS_WARNING_GCC_PUSH
+    #if defined(__GNUC__) && __GNUC__ > 6
+    C4_SUPPRESS_WARNING_GCC("-Wrestrict")
+    #endif
+    CAPTURE(v);
+    char buf_[256];
+    substr buf = buf_;
+    buf.fill(0);
+    CAPTURE(buf);
+    REQUIRE_EQ(expected.len,  cat(buf, v, v, v, v, v));
+    CHECK_EQ(expected, substr(buf).first(expected.len));
+    buf.fill(0);
+    CHECK_EQ(expected,  cat_sub(buf, v, v, v, v, v));
+    buf.fill(0);
+    CHECK_EQ(expected,  catrs<std::string>(v, v, v, v, v));
+    buf.fill(0);
+    CHECK_EQ(expected,  catrs<std::vector<char>>(v, v, v, v, v));
+    C4_SUPPRESS_WARNING_GCC_POP
+}
+TEST_CASE_TEMPLATE("cat.samevar_integral", T,
+                   int8_t, uint8_t,
+                   int16_t, uint16_t,
+                   int32_t, uint32_t,
+                   int64_t, uint64_t,
+                   int, uintptr_t,
+                   float, double)
+{
+    T val0 = 1;
+    T val1 = 12;
+    test_cat_samevar5<T>(val0, "11111");
+    test_cat_samevar5<T>(val1, "1212121212");
+}
+TEST_CASE_TEMPLATE("cat.samevar_char", T, char)
+{
+    T val0 = '1';
+    T val1 = '2';
+    test_cat_samevar5<T>(val0, "11111");
+    test_cat_samevar5<T>(val1, "22222");
+}
+TEST_CASE_TEMPLATE("cat.samevar_str", T, std::string)
+{
+    T val0 = "ab";
+    T val1 = "cd";
+    test_cat_samevar5<T>(val0, "ababababab");
+    test_cat_samevar5<T>(val1, "cdcdcdcdcd");
+}
+TEST_CASE_TEMPLATE("cats.samevar_str", T, char, const char)
+{
+    T val0_[] = "ab";
+    T val1_[] = "cd";
+    T *val0 = val0_;
+    T *val1 = val1_;
+    test_cat_samevar5<T*>(val0, "ababababab");
+    test_cat_samevar5<T*>(val1, "cdcdcdcdcd");
+}
+TEST_CASE("cat.samevar_str.char_arr")
+{
+    char val0[] = "ab";
+    char val1[] = "cd";
+    test_cat_samevar5<char [3]>(val0, "ababababab");
+    test_cat_samevar5<char [3]>(val1, "cdcdcdcdcd");
+}
+TEST_CASE("cat.samevar_str.const_char_arr")
+{
+    const char val0[] = "ab";
+    const char val1[] = "cd";
+    test_cat_samevar5<const char [3]>(val0, "ababababab");
+    test_cat_samevar5<const char [3]>(val1, "cdcdcdcdcd");
+}
+
+
+//-----------------------------------------------------------------------------
+
 TEST_CASE("uncat.vars")
 {
     size_t sz;
@@ -661,6 +740,8 @@ TEST_CASE("uncat.tuple")
 }
 #endif // C4_TUPLE_TO_STR
 
+
+//-----------------------------------------------------------------------------
 
 TEST_CASE("catsep.vars")
 {
@@ -766,6 +847,86 @@ TEST_CASE("catsep.tuple")
     CHECK_EQ(result, "1/2/3/4");
 }
 #endif // C4_TUPLE_TO_STR
+
+
+//-----------------------------------------------------------------------------
+
+template<class T>
+void test_catsep_samevar5(T & v, csubstr expected)
+{
+    C4_SUPPRESS_WARNING_GCC_PUSH
+    #if defined(__GNUC__) && __GNUC__ > 6
+    C4_SUPPRESS_WARNING_GCC("-Wrestrict")
+    #endif
+    CAPTURE(v);
+    csubstr sep = "--";
+    char buf_[256];
+    substr buf = buf_;
+    buf.fill(0);
+    CAPTURE(buf);
+    REQUIRE_EQ(expected.len,  catsep(buf, sep, v, v, v, v, v));
+    CHECK_EQ(expected, substr(buf).first(expected.len));
+    buf.fill(0);
+    CHECK_EQ(expected,  catsep_sub(buf, sep, v, v, v, v, v));
+    buf.fill(0);
+    CHECK_EQ(expected,  catseprs<std::string>(sep, v, v, v, v, v));
+    buf.fill(0);
+    CHECK_EQ(expected,  catseprs<std::vector<char>>(sep, v, v, v, v, v));
+    C4_SUPPRESS_WARNING_GCC_POP
+}
+TEST_CASE_TEMPLATE("catsep.samevar_integral", T,
+                   int8_t, uint8_t,
+                   int16_t, uint16_t,
+                   int32_t, uint32_t,
+                   int64_t, uint64_t,
+                   int, uintptr_t,
+                   float, double)
+{
+    T val0 = 1;
+    T val1 = 12;
+    test_catsep_samevar5<T>(val0, "1--1--1--1--1");
+    test_catsep_samevar5<T>(val1, "12--12--12--12--12");
+}
+TEST_CASE_TEMPLATE("catsep.samevar_char", T, char)
+{
+    T val0 = '1';
+    T val1 = '2';
+    test_catsep_samevar5<T>(val0, "1--1--1--1--1");
+    test_catsep_samevar5<T>(val1, "2--2--2--2--2");
+}
+TEST_CASE_TEMPLATE("catsep.samevar_str", T, std::string)
+{
+    T val0 = "ab";
+    T val1 = "cd";
+    test_catsep_samevar5<T>(val0, "ab--ab--ab--ab--ab");
+    test_catsep_samevar5<T>(val1, "cd--cd--cd--cd--cd");
+}
+TEST_CASE_TEMPLATE("catsep.samevar_str", T, char, const char)
+{
+    T val0_[] = "ab";
+    T val1_[] = "cd";
+    T *val0 = val0_;
+    T *val1 = val1_;
+    test_catsep_samevar5<T*>(val0, "ab--ab--ab--ab--ab");
+    test_catsep_samevar5<T*>(val1, "cd--cd--cd--cd--cd");
+}
+TEST_CASE("catsep.samevar_str.char_arr")
+{
+    char val0[] = "ab";
+    char val1[] = "cd";
+    test_catsep_samevar5<char [3]>(val0, "ab--ab--ab--ab--ab");
+    test_catsep_samevar5<char [3]>(val1, "cd--cd--cd--cd--cd");
+}
+TEST_CASE("catsep.samevar_str.const_char_arr")
+{
+    const char val0[] = "ab";
+    const char val1[] = "cd";
+    test_catsep_samevar5<const char [3]>(val0, "ab--ab--ab--ab--ab");
+    test_catsep_samevar5<const char [3]>(val1, "cd--cd--cd--cd--cd");
+}
+
+
+//-----------------------------------------------------------------------------
 
 TEST_CASE("uncatsep.vars")
 {
@@ -1011,6 +1172,86 @@ TEST_CASE("format.tuple")
     CHECK_EQ(result, "{} and {} and {} and {}");
 }
 #endif // C4_TUPLE_TO_STR
+
+
+
+//-----------------------------------------------------------------------------
+
+template<class T>
+void test_format_samevar5(csubstr fmt, T & v, csubstr expected)
+{
+    C4_SUPPRESS_WARNING_GCC_PUSH
+    #if defined(__GNUC__) && __GNUC__ > 6
+    C4_SUPPRESS_WARNING_GCC("-Wrestrict")
+    #endif
+    CAPTURE(v);
+    char buf_[256];
+    substr buf = buf_;
+    buf.fill(0);
+    CAPTURE(buf);
+    REQUIRE_EQ(expected.len,  format(buf, fmt, v, v, v, v, v));
+    CHECK_EQ(expected, substr(buf).first(expected.len));
+    buf.fill(0);
+    CHECK_EQ(expected,  format_sub(buf, fmt, v, v, v, v, v));
+    buf.fill(0);
+    CHECK_EQ(expected,  formatrs<std::string>(fmt, v, v, v, v, v));
+    buf.fill(0);
+    CHECK_EQ(expected,  formatrs<std::vector<char>>(fmt, v, v, v, v, v));
+    C4_SUPPRESS_WARNING_GCC_POP
+}
+TEST_CASE_TEMPLATE("format.samevar_integral", T,
+                   int8_t, uint8_t,
+                   int16_t, uint16_t,
+                   int32_t, uint32_t,
+                   int64_t, uint64_t,
+                   int, uintptr_t,
+                   float, double)
+{
+    T val0 = 1;
+    T val1 = 12;
+    test_format_samevar5<T>("{}--{}--{}--{}--{}", val0, "1--1--1--1--1");
+    test_format_samevar5<T>("{}--{}--{}--{}--{}", val1, "12--12--12--12--12");
+}
+TEST_CASE_TEMPLATE("format.samevar_char", T, char)
+{
+    T val0 = '1';
+    T val1 = '2';
+    test_format_samevar5<T>("{}--{}--{}--{}--{}", val0, "1--1--1--1--1");
+    test_format_samevar5<T>("{}--{}--{}--{}--{}", val1, "2--2--2--2--2");
+}
+TEST_CASE_TEMPLATE("format.samevar_str", T, char, const char)
+{
+    T val0_[] = "ab";
+    T val1_[] = "cd";
+    T *val0 = val0_;
+    T *val1 = val1_;
+    test_format_samevar5<T*>("{}--{}--{}--{}--{}", val0, "ab--ab--ab--ab--ab");
+    test_format_samevar5<T*>("{}--{}--{}--{}--{}", val1, "cd--cd--cd--cd--cd");
+}
+TEST_CASE_TEMPLATE("format.samevar_str", T, std::string)
+{
+    T val0 = "ab";
+    T val1 = "cd";
+    test_format_samevar5<T>("{}--{}--{}--{}--{}", val0, "ab--ab--ab--ab--ab");
+    test_format_samevar5<T>("{}--{}--{}--{}--{}", val1, "cd--cd--cd--cd--cd");
+}
+TEST_CASE("format.samevar_str.char_arr")
+{
+    char val0[] = "ab";
+    char val1[] = "cd";
+    test_format_samevar5<char [3]>("{}--{}--{}--{}--{}", val0, "ab--ab--ab--ab--ab");
+    test_format_samevar5<char [3]>("{}--{}--{}--{}--{}", val1, "cd--cd--cd--cd--cd");
+}
+TEST_CASE("format.samevar_str.const_char_arr")
+{
+    const char val0[] = "ab";
+    const char val1[] = "cd";
+    test_format_samevar5<const char [3]>("{}--{}--{}--{}--{}", val0, "ab--ab--ab--ab--ab");
+    test_format_samevar5<const char [3]>("{}--{}--{}--{}--{}", val1, "cd--cd--cd--cd--cd");
+}
+
+
+//-----------------------------------------------------------------------------
 
 TEST_CASE("unformat.vars")
 {

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -930,16 +930,94 @@ TEST_CASE("catsep.samevar_str.const_char_arr")
 
 TEST_CASE("uncatsep.vars")
 {
-    size_t sz;
-    int v1 = 0, v2 = 0, v3 = 0, v4 = 0;
-    char sep;
+    csubstr seps[] = {
+        csubstr(" "),
+        csubstr("-"),
+        csubstr("--"),
+        csubstr("@"),
+        csubstr(" --- "),
+        csubstr("\t"),
+    };
+    std::string buf_;
+    for(csubstr sep : seps)
+    {
+        CAPTURE(sep);
+        catseprs(&buf_, sep, 1, 2, 3, 4);
+        csubstr buf = to_csubstr(buf_);
+        int v1 = 0, v2 = 0, v3 = 0, v4 = 0;
+        size_t sz = uncatsep(buf, sep, v1, v2, v3, v4);
+        CHECK_EQ(sz, buf.len);
+        CHECK_EQ(v1, 1);
+        CHECK_EQ(v2, 2);
+        CHECK_EQ(v3, 3);
+        CHECK_EQ(v4, 4);
+    }
+    for(csubstr sep : seps)
+    {
+        CAPTURE(sep);
+        catseprs(&buf_, sep, "1", "2", "3", "4");
+        csubstr buf = to_csubstr(buf_);
+        std::string v1, v2, v3, v4;
+        size_t sz = uncatsep(buf, sep, v1, v2, v3, v4);
+        CHECK_EQ(sz, buf.len);
+        CHECK_EQ(v1, "1");
+        CHECK_EQ(v2, "2");
+        CHECK_EQ(v3, "3");
+        CHECK_EQ(v4, "4");
+    }
+}
 
-    sz = uncatsep("1 2 3 4", sep, v1, v2, v3, v4);
-    CHECK_EQ(sz, 7);
-    CHECK_EQ(v1, 1);
-    CHECK_EQ(v2, 2);
-    CHECK_EQ(v3, 3);
-    CHECK_EQ(v4, 4);
+TEST_CASE("uncatsep.fail")
+{
+    int v1 = 0, v2 = 0, v3 = 0, v4 = 0;
+    {
+        csubstr sep = " ";
+        CHECK_EQ(csubstr::npos, uncatsep("", sep, v1));
+        CHECK_EQ(csubstr::npos, uncatsep("1", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep("1 ", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 ", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep("1-", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1-", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2 ", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2 ", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2-", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2-", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2 3", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2 3", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2 3 ", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2 3 ", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2 3-", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2 3-", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("- 2 3 4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" - 2 3 4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1 - 3 4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 - 3 4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2 - 4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2 - 4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1 2 3 -", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep(" 1 2 3 -", sep, v1, v2, v3, v4));
+    }
+    {
+        csubstr sep = "@";
+        CHECK_EQ(csubstr::npos, uncatsep("", sep, v1));
+        CHECK_EQ(csubstr::npos, uncatsep("1", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep("1@", sep, v1, v2));
+        CHECK_EQ(3            , uncatsep("1@2", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep("1-2", sep, v1, v2));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2@", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2-", sep, v1, v2, v3));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2@3", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2@3@", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2@3-", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("-@2@3@4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1@-@3@4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2@-@4", sep, v1, v2, v3, v4));
+        CHECK_EQ(csubstr::npos, uncatsep("1@2@3@-", sep, v1, v2, v3, v4));
+    }
 }
 
 #ifdef C4_TUPLE_TO_STR

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -242,6 +242,13 @@ TEST_CASE("align.right.overflow")
     CHECK_EQ(to_chars(substr(), fmt::right("0123456789.123456789.123456789.123456789", 30u)), 40u);
 }
 
+TEST_CASE("align.center.overflow")
+{
+    CHECK_EQ(to_chars(substr(), fmt::center(' ', 91u)), 91u);
+    CHECK_EQ(to_chars(substr(), fmt::center("0123456789.123456789.123456789.123456789", 91u)), 91u);
+    CHECK_EQ(to_chars(substr(), fmt::center("0123456789.123456789.123456789.123456789", 30u)), 40u);
+}
+
 TEST_CASE("align.left")
 {
     char buf[128] = {};
@@ -255,6 +262,7 @@ TEST_CASE("align.left")
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 8)), "1       ");
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 9)), "1        ");
 
+    CHECK_EQ(to_chars_sub(buf, fmt::left("1", 0, '+')), "1");
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 1, '+')), "1");
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 2, '+')), "1+");
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 3, '+')), "1++");
@@ -264,6 +272,17 @@ TEST_CASE("align.left")
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 7, '+')), "1++++++");
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 8, '+')), "1+++++++");
     CHECK_EQ(to_chars_sub(buf, fmt::left("1", 9, '+')), "1++++++++");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 0, '+')), "");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 1, '+')), "+");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 2, '+')), "++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 3, '+')), "+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 4, '+')), "++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 5, '+')), "+++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 6, '+')), "++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 7, '+')), "+++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 8, '+')), "++++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::left("", 9, '+')), "+++++++++");
 
     CHECK_EQ(to_chars_sub(buf, fmt::left("01234", 0)), "01234");
     CHECK_EQ(to_chars_sub(buf, fmt::left("01234", 1)), "01234");
@@ -286,6 +305,19 @@ TEST_CASE("align.left")
     CHECK_EQ(to_chars_sub(buf, fmt::left(1234, 7)), "1234   ");
     CHECK_EQ(to_chars_sub(buf, fmt::left(1234, 8)), "1234    ");
     CHECK_EQ(to_chars_sub(buf, fmt::left(1234, 9)), "1234     ");
+
+    // using std::cref to avoid a copy:
+    csubstr s = "1234";
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 0)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 1)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 2)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 3)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 4)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 5)), "1234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 6)), "1234  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 7)), "1234   ");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 8)), "1234    ");
+    CHECK_EQ(to_chars_sub(buf, fmt::left(std::cref(s), 9)), "1234     ");
 }
 
 
@@ -302,6 +334,7 @@ TEST_CASE("align.right")
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 8)), "       1");
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 9)), "        1");
 
+    CHECK_EQ(to_chars_sub(buf, fmt::right("1", 0, '+')), "1");
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 1, '+')), "1");
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 2, '+')), "+1");
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 3, '+')), "++1");
@@ -311,6 +344,17 @@ TEST_CASE("align.right")
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 7, '+')), "++++++1");
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 8, '+')), "+++++++1");
     CHECK_EQ(to_chars_sub(buf, fmt::right("1", 9, '+')), "++++++++1");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 0, '+')), "");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 1, '+')), "+");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 2, '+')), "++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 3, '+')), "+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 4, '+')), "++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 5, '+')), "+++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 6, '+')), "++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 7, '+')), "+++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 8, '+')), "++++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::right("", 9, '+')), "+++++++++");
 
     CHECK_EQ(to_chars_sub(buf, fmt::right("01234", 0)), "01234");
     CHECK_EQ(to_chars_sub(buf, fmt::right("01234", 1)), "01234");
@@ -363,11 +407,145 @@ TEST_CASE("align.right")
     CHECK_EQ(to_chars_sub(buf, fmt::right(fmt::real(0.124, 3), 7)), "  0.124");
 
     CHECK_EQ(to_chars_sub(buf, fmt::right(fmt::real(1234.5222, 1), 7)), " 1234.5");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(fmt::real(1234.5222, 1), 7)), " 1234.5");
     auto r = [](double val, size_t width) { return fmt::right(fmt::real(val, 1), width); };
     CHECK_EQ(to_chars_sub(buf, r(1234.5, 7)), " 1234.5");
     c4::format(buf, "freq={}Hz\0", r(1234.5, 7));
     CHECK_EQ(to_csubstr((const char*)buf).len, to_csubstr("freq= 1234.5Hz").len);
     CHECK_EQ(to_csubstr((const char*)buf), "freq= 1234.5Hz");
+
+    // using std::cref to avoid a copy:
+    csubstr s = "1234";
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 0)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 1)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 2)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 3)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 4)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 5)), " 1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 6)), "  1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 7)), "   1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 8)), "    1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::right(std::cref(s), 9)), "     1234");
+}
+
+TEST_CASE("align.center")
+{
+    char buf[128] = {};
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 1)), "1");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 2)), "1 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 3)), " 1 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 4)), " 1  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 5)), "  1  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 6)), "  1   ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 7)), "   1   ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 8)), "   1    ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 9)), "    1    ");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 1, '+')), "1");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 2, '+')), "1+");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 3, '+')), "+1+");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 4, '+')), "+1++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 5, '+')), "++1++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 6, '+')), "++1+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 7, '+')), "+++1+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 8, '+')), "+++1++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("1", 9, '+')), "++++1++++");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 1, '+')), "12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 2, '+')), "12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 3, '+')), "12+");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 4, '+')), "+12+");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 5, '+')), "+12++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 6, '+')), "++12++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 7, '+')), "++12+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 8, '+')), "+++12+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12", 9, '+')), "+++12++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("12",10, '+')), "++++12++++");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 0, '+')), "");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 1, '+')), "+");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 2, '+')), "++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 3, '+')), "+++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 4, '+')), "++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 5, '+')), "+++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 6, '+')), "++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 7, '+')), "+++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 8, '+')), "++++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("", 9, '+')), "+++++++++");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("",10, '+')), "++++++++++");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 0)), "01234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 1)), "01234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 2)), "01234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 3)), "01234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 4)), "01234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 5)), "01234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 6)), "01234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 7)), " 01234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 8)), " 01234  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center("01234", 9)), "  01234  ");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 0)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 1)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 2)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 3)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 4)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 5)), "1234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 6)), " 1234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 7)), " 1234  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 8)), "  1234  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234, 9)), "  1234   ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(1234,10)), "   1234   ");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::real(0.124, 1)), "0.1"); // we assume this in what follows
+    CHECK_EQ(to_chars_sub(buf, fmt::real(0.124, 2)), "0.12");
+    CHECK_EQ(to_chars_sub(buf, fmt::real(0.124, 3)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 0)), "0.1");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 1)), "0.1");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 2)), "0.1");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 3)), "0.1");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 4)), "0.1 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 5)), " 0.1 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 6)), " 0.1  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 1), 7)), "  0.1  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 0)), "0.12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 1)), "0.12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 2)), "0.12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 3)), "0.12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 4)), "0.12");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 5)), "0.12 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 6)), " 0.12 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 2), 7)), " 0.12  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 0)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 1)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 2)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 3)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 4)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 5)), "0.124");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 6)), "0.124 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(0.124, 3), 7)), " 0.124 ");
+
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(1234.5222, 1), 7)), "1234.5 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(fmt::real(1234.5222, 1), 8)), " 1234.5 ");
+    auto r = [](double val, size_t width) { return fmt::center(fmt::real(val, 1), width); };
+    CHECK_EQ(to_chars_sub(buf, r(1234.5, 7)), "1234.5 ");
+    c4::format(buf, "freq={}Hz\0", r(1234.5, 7));
+    CHECK_EQ(to_csubstr((const char*)buf).len, to_csubstr("freq=1234.5 Hz").len);
+    CHECK_EQ(to_csubstr((const char*)buf), "freq=1234.5 Hz");
+
+    // using std::cref to avoid a copy:
+    csubstr s = "1234";
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 0)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 1)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 2)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 3)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 4)), "1234");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 5)), "1234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 6)), " 1234 ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 7)), " 1234  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 8)), "  1234  ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s), 9)), "  1234   ");
+    CHECK_EQ(to_chars_sub(buf, fmt::center(std::cref(s),10)), "   1234   ");
 }
 
 

--- a/test/test_szconv.cpp
+++ b/test/test_szconv.cpp
@@ -121,37 +121,13 @@ test_szconv()
 }
 
 #define DO_TEST_SZCONV(ty)                      \
-    TEST_CASE("szconv." #ty "_to_int8")         \
+    TEST_CASE_TEMPLATE("szconv." #ty "_to", T,  \
+                       int8_t, uint8_t,         \
+                       int16_t, uint16_t,       \
+                       int32_t, uint32_t,       \
+                       int64_t, uint64_t)       \
     {                                           \
-        test_szconv<ty##_t, int8_t>();          \
-    }                                           \
-    TEST_CASE("zconv." #ty "_to_uint8")         \
-    {                                           \
-        test_szconv<ty##_t, uint8_t>();         \
-    }                                           \
-    TEST_CASE("zconv." #ty "_to_int16")         \
-    {                                           \
-        test_szconv<ty##_t, int16_t>();         \
-    }                                           \
-    TEST_CASE("zconv." #ty "_to_uint16")        \
-    {                                           \
-        test_szconv<ty##_t, uint16_t>();        \
-    }                                           \
-    TEST_CASE("zconv." #ty "_to_int32")         \
-    {                                           \
-        test_szconv<ty##_t, int32_t>();         \
-    }                                           \
-    TEST_CASE("zconv." #ty "_to_uint32")        \
-    {                                           \
-        test_szconv<ty##_t, uint32_t>();        \
-    }                                           \
-    TEST_CASE("zconv." #ty "_to_int64")         \
-    {                                           \
-        test_szconv<ty##_t, int64_t>();         \
-    }                                           \
-    TEST_CASE("szconv." #ty "_to_uint64")       \
-    {                                           \
-        test_szconv<ty##_t, uint64_t>();        \
+        test_szconv<ty##_t, T>();               \
     }
 
 DO_TEST_SZCONV(int8)


### PR DESCRIPTION
  - charconv.hpp:
    - minor simplification of `atoi_first()` and `atou_first()`
    - add implementation of `to_chars()` for raw char pointers
    - improve `from_chars()` for bool
  - format.hpp:
    - simplify `boolalpha()` implementation
    - `catrs()`/`catseprs()`/`formatrs()`: resize to capacity before trying
    - fix `uncatsep()`: force sep as a csubstr, and enforce it
    - `cat()`/`catsep()`/`format(): add tests to ensure repeated args
    - improve implementation of `fmt::left()`/`fmt::right()`. add `fmt::center()`
  - Improve doxygen comments
