### PR TITLE
Fix/substr sfinae

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,6 +69,7 @@ Checks:
   - -misc-no-recursion # function 'reserve' is within a recursive call chain
   - -misc-non-private-member-variables-in-classes # member variable 'data' has public visibility
   - -modernize-avoid-c-arrays # allow C arrays
+  - -modernize-avoid-c-style-cast
   - -modernize-concat-nested-namespaces # nested namespaces can be concatenated
   - -modernize-deprecated-headers # inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
   - -modernize-deprecated-headers # inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
@@ -91,6 +92,7 @@ Checks:
   - -readability-identifier-length # variable name 'c' is too short, expected at least 3 characters
   - -readability-implicit-bool-conversion # implicit conversion 'NodeData *' -> 'bool'
   - -readability-inconsistent-declaration-parameter-name # definition with different parameter names
+  - -readability-inconsistent-ifelse-braces
   - -readability-isolate-declaration # multiple declarations in a single statement reduces readability
   - -readability-magic-numbers # 16 is a magic number; consider replacing it with a named constant
   - -readability-math-missing-parentheses # 

--- a/.github/workflows/windows.ys
+++ b/.github/workflows/windows.ys
@@ -103,7 +103,7 @@ jobs:
 
   #----------------------------------------------------------------------------
   vsclang:
-    :: setup-job('windows' 'clang')
+    :: setup-job('windows' 'vsclang')
     name: vsclang/c++${{matrix.std}}/${{matrix.bt}}
     runs-on: windows-${{matrix.os}}
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(C4CORE_SRC_FILES
     c4/std/string.hpp
     c4/std/string_fwd.hpp
     c4/std/string_view.hpp
+    c4/std/string_view_fwd.hpp
     c4/std/tuple.hpp
     c4/std/vector.hpp
     c4/std/vector_fwd.hpp

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -2,6 +2,7 @@
   - `substr`:
     - improve SFINAE rules and overloads
     - add member type `value_type`
+  - Improve std interop headers
   - `type_name()`:
     - make `noexcept`
     - return a new dedicated type `TypeNameStr`. This spares costly include of span.hpp

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,0 +1,5 @@
+- [PR#166](https://github.com/biojppm/c4core/pull/166)
+  - `type_name()`:
+    - make `noexcept`
+    - return a new dedicated type `TypeNameStr`. This spares costly include of span.hpp
+

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -7,4 +7,5 @@
     - return a new dedicated type `TypeNameStr`. This spares costly include of span.hpp
   - Improve std interop headers
   - Fix: `from_chars_first()` must use `csubstr` for the chars parameters
+  - clang-tidy fixes with clang-22
 

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,9 +1,10 @@
-- [PR#166](https://github.com/biojppm/c4core/pull/166)
+- [PR#166](https://github.com/biojppm/c4core/pull/166): fixes to `substr` and `type_name()`
   - `substr`:
     - improve SFINAE rules and overloads
     - add member type `value_type`
-  - Improve std interop headers
   - `type_name()`:
     - make `noexcept`
     - return a new dedicated type `TypeNameStr`. This spares costly include of span.hpp
+  - Improve std interop headers
+  - Fix: `from_chars_first()` must use `csubstr` for the chars parameters
 

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,4 +1,7 @@
 - [PR#166](https://github.com/biojppm/c4core/pull/166)
+  - `substr`:
+    - improve SFINAE rules and overloads
+    - add member type `value_type`
   - `type_name()`:
     - make `noexcept`
     - return a new dedicated type `TypeNameStr`. This spares costly include of span.hpp

--- a/src/c4/base64.cpp
+++ b/src/c4/base64.cpp
@@ -144,7 +144,7 @@ size_t base64_encode(substr buf, cblob data)
     }
     else if(rem == 1)
     {
-        const uint32_t val = ((uint32_t(d[0]) << 16));
+        const uint32_t val = (uint32_t(d[0]) << 16);
         c4append_idx_((val >> 18) & sextet_mask);
         c4append_idx_((val >> 12) & sextet_mask);
         c4append_('=');

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -281,7 +281,7 @@ template<> struct charconv_digits_<1u, true> // int8_t
     static constexpr csubstr min_value_oct() noexcept { return csubstr("200"); }
     static constexpr csubstr min_value_bin() noexcept { return csubstr("10000000"); }
     static constexpr csubstr max_value_dec() noexcept { return csubstr("127"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 3) || (str.len == 3 && str[0] <= '1')); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 3) || (str.len == 3 && str.str[0] <= '1')); }
 };
 template<> struct charconv_digits_<1u, false> // uint8_t
 {
@@ -296,7 +296,7 @@ template<> struct charconv_digits_<1u, false> // uint8_t
         maxdigits_hex_nopfx =     2, // 255 0xff
     };
     static constexpr csubstr max_value_dec() noexcept { return csubstr("255"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 3) || (str.len == 3 && str[0] <= '3')); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 3) || (str.len == 3 && str.str[0] <= '3')); }
 };
 template<> struct charconv_digits_<2u, true> // int16_t
 {
@@ -316,7 +316,7 @@ template<> struct charconv_digits_<2u, true> // int16_t
     static constexpr csubstr min_value_oct() noexcept { return csubstr("100000"); }
     static constexpr csubstr min_value_bin() noexcept { return csubstr("1000000000000000"); }
     static constexpr csubstr max_value_dec() noexcept { return csubstr("32767"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 6)); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !(str.len < 6); }
 };
 template<> struct charconv_digits_<2u, false> // uint16_t
 {
@@ -331,7 +331,7 @@ template<> struct charconv_digits_<2u, false> // uint16_t
         maxdigits_hex_nopfx =      4, // 65535 0xffff
     };
     static constexpr csubstr max_value_dec() noexcept { return csubstr("65535"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 6) || (str.len == 6 && str[0] <= '1')); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 6) || (str.len == 6 && str.str[0] <= '1')); }
 };
 template<> struct charconv_digits_<4u, true> // int32_t
 {
@@ -351,7 +351,7 @@ template<> struct charconv_digits_<4u, true> // int32_t
     static constexpr csubstr min_value_oct() noexcept { return csubstr("20000000000"); }
     static constexpr csubstr min_value_bin() noexcept { return csubstr("10000000000000000000000000000000"); }
     static constexpr csubstr max_value_dec() noexcept { return csubstr("2147483647"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 11) || (str.len == 11 && str[0] <= '1')); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 11) || (str.len == 11 && str.str[0] <= '1')); }
 };
 template<> struct charconv_digits_<4u, false> // uint32_t
 {
@@ -366,7 +366,7 @@ template<> struct charconv_digits_<4u, false> // uint32_t
         maxdigits_hex_nopfx =      8, // len=10: 4294967295 0xffffffff
     };
     static constexpr csubstr max_value_dec() noexcept { return csubstr("4294967295"); }
-    static constexpr bool is_oct_overflow(csubstr str) noexcept { return !((str.len < 11) || (str.len == 11 && str[0] <= '3')); }
+    static constexpr bool is_oct_overflow(csubstr str) noexcept { return !((str.len < 11) || (str.len == 11 && str.str[0] <= '3')); }
 };
 template<> struct charconv_digits_<8u, true> // int64_t
 {
@@ -385,7 +385,7 @@ template<> struct charconv_digits_<8u, true> // int64_t
     static constexpr csubstr min_value_oct() noexcept { return csubstr("1000000000000000000000"); }
     static constexpr csubstr min_value_bin() noexcept { return csubstr("1000000000000000000000000000000000000000000000000000000000000000"); }
     static constexpr csubstr max_value_dec() noexcept { return csubstr("9223372036854775807"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 22)); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !(str.len < 22); }
 };
 template<> struct charconv_digits_<8u, false> // uint64_t
 {
@@ -400,7 +400,7 @@ template<> struct charconv_digits_<8u, false> // uint64_t
         maxdigits_hex_nopfx =     16, // len=18: 18446744073709551615 0xffffffffffffffff
     };
     static constexpr csubstr max_value_dec() noexcept { return csubstr("18446744073709551615"); }
-    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 22) || (str.len == 22 && str[0] <= '1')); }
+    static constexpr bool    is_oct_overflow(csubstr str) noexcept { return !((str.len < 22) || (str.len == 22 && str.str[0] <= '1')); }
 };
 } // namespace detail
 
@@ -484,16 +484,26 @@ auto digits_dec(T v) noexcept
                     return (v >= 1000000000000000000) ? 19u : 18u;
             }
             else if(v >= 10000000000000000) // 17
+            {
                 return 17u;
+            }
             else
+            {
                 return(v >= 1000000000000000) ? 16u : 15u;
+            }
         }
         else if(v >= 1000000000000) // 13
+        {
             return (v >= 10000000000000) ? 14u : 13u;
+        }
         else if(v >= 100000000000) // 12
+        {
             return 12;
+        }
         else
+        {
             return(v >= 10000000000) ? 11u : 10u;
+        }
     }
     else if(v >= 10000) // 5 [5-9] range
     {
@@ -505,9 +515,13 @@ auto digits_dec(T v) noexcept
             return (v >= 100000) ? 6u : 5u;
     }
     else if(v >= 100)
+    {
         return (v >= 1000) ? 4u : 3u;
+    }
     else
+    {
         return (v >= 10) ? 2u : 1u;
+    }
 }
 
 
@@ -1615,9 +1629,9 @@ inline bool check_overflow(csubstr str, csubstr limit) noexcept
         return str.len > limit.len;
     for(size_t i = 0; i < limit.len; ++i)
     {
-        if(str[i] < limit[i])
+        if(str.str[i] < limit.str[i])
             return false;
-        else if(str[i] > limit[i])
+        else if(str.str[i] > limit.str[i])
             return true;
     }
     return false;
@@ -1685,7 +1699,7 @@ auto overflows(csubstr str) noexcept
             }
         }
     }
-    else if(C4_UNLIKELY(str[0] == '-'))
+    else if(C4_UNLIKELY(str.str[0] == '-'))
     {
         return true;
     }
@@ -1769,7 +1783,7 @@ auto overflows(csubstr str) noexcept
                 if (fno == csubstr::npos)
                     return false;
                 const size_t len = str.len - fno;
-                return !((len < sizeof (T) * 2) || (len == sizeof(T) * 2 && str[fno] <= '7'));
+                return !((len < sizeof (T) * 2) || (len == sizeof(T) * 2 && str.str[fno] <= '7'));
             }
             case 'b':
             case 'B':
@@ -2465,8 +2479,8 @@ inline bool from_chars(csubstr buf, bool * C4_RESTRICT v) noexcept
     {
         if(((buf.str[0] == 't') && (0 == memcmp(buf.str + 1, "rue", 3)))
            ||
-           ((buf.str[0] == 'T') && ((0 == memcmp(buf.str + 1, "rue", 3) ||
-                                     0 == memcmp(buf.str + 1, "RUE", 3)))))
+           ((buf.str[0] == 'T') && (0 == memcmp(buf.str + 1, "rue", 3) ||
+                                    0 == memcmp(buf.str + 1, "RUE", 3))))
         {
             *v = true; return true;
         }
@@ -2475,8 +2489,8 @@ inline bool from_chars(csubstr buf, bool * C4_RESTRICT v) noexcept
     {
         if(((buf.str[0] == 'f') && (0 == memcmp(buf.str + 1, "alse", 4)))
            ||
-           ((buf.str[0] == 'F') && ((0 == memcmp(buf.str + 1, "alse", 4) ||
-                                     0 == memcmp(buf.str + 1, "ALSE", 4)))))
+           ((buf.str[0] == 'F') && (0 == memcmp(buf.str + 1, "alse", 4) ||
+                                    0 == memcmp(buf.str + 1, "ALSE", 4))))
         {
             *v = false; return true;
         }

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -2566,7 +2566,7 @@ inline bool from_chars(csubstr buf, csubstr *C4_RESTRICT v) noexcept
 }
 
 /** @ingroup doc_from_chars_first */
-inline size_t from_chars_first(substr buf, csubstr * C4_RESTRICT v) noexcept
+inline size_t from_chars_first(csubstr buf, csubstr * C4_RESTRICT v) noexcept
 {
     csubstr trimmed = buf.first_non_empty_span();
     if(trimmed.len == 0)

--- a/src/c4/error.cpp
+++ b/src/c4/error.cpp
@@ -76,7 +76,7 @@ void set_error_callback(error_callback_type cb)
 
 //-----------------------------------------------------------------------------
 
-void handle_error(srcloc where, const char *fmt, ...)
+void handle_error(srcloc where, const char *fmt, ...) // NOLINT
 {
     char buf[1024];
     size_t msglen = 0;
@@ -129,7 +129,7 @@ void handle_error(srcloc where, const char *fmt, ...)
 
 //-----------------------------------------------------------------------------
 
-void handle_warning(srcloc where, const char *fmt, ...)
+void handle_warning(srcloc where, const char *fmt, ...) // NOLINT
 {
     va_list args;
     char buf[1024];

--- a/src/c4/std/span.hpp
+++ b/src/c4/std/span.hpp
@@ -30,6 +30,7 @@ template<> struct is_string<const std::span<const char>> : public std::true_type
 template<> struct is_string<std::span<char>> : public std::true_type {};
 template<> struct is_string<const std::span<char>> : public std::true_type {};
 template<> struct is_writeable_string<std::span<char>> : public std::true_type {};
+template<> struct is_writeable_string<const std::span<char>> : public std::true_type {};
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/std/span.hpp
+++ b/src/c4/std/span.hpp
@@ -24,9 +24,11 @@ template<class T> struct is_writeable_string;
 
 // mark std::span<const char> as a string type
 template<> struct is_string<std::span<const char>> : public std::true_type {};
+template<> struct is_string<const std::span<const char>> : public std::true_type {};
 
 // mark std::span<char> as a string type
 template<> struct is_string<std::span<char>> : public std::true_type {};
+template<> struct is_string<const std::span<char>> : public std::true_type {};
 template<> struct is_writeable_string<std::span<char>> : public std::true_type {};
 
 

--- a/src/c4/std/span_fwd.hpp
+++ b/src/c4/std/span_fwd.hpp
@@ -23,11 +23,14 @@ template<class T> struct is_string;
 template<class T> struct is_writeable_string;
 
 // mark std::span<const char> as a string type
-template<> struct is_string<std::span<const char>>;
+template<> struct is_string<std::span<const char>> : public std::true_type {};
+template<> struct is_string<const std::span<const char>> : public std::true_type {};
 
 // mark std::span<char> as a string type
-template<> struct is_string<std::span<char>>;
-template<> struct is_writeable_string<std::span<char>>;
+template<> struct is_string<std::span<char>> : public std::true_type {};
+template<> struct is_string<const std::span<char>> : public std::true_type {};
+template<> struct is_writeable_string<std::span<char>> : public std::true_type {};
+template<> struct is_writeable_string<const std::span<char>> : public std::true_type {};
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/std/span_fwd.hpp
+++ b/src/c4/std/span_fwd.hpp
@@ -1,7 +1,9 @@
 #ifndef _C4_STD_SPAN_FWD_HPP_
 #define _C4_STD_SPAN_FWD_HPP_
 
-/** @file span_fwd.hpp */
+/** @file span_fwd.hpp Provides forward declaration of std::span
+ * to enable order-independent includes for use with ref @ref
+ * c4::to_chars() and @ref c4::from_chars(). */
 
 #ifndef C4CORE_SINGLE_HEADER
 #include "c4/language.hpp"
@@ -23,14 +25,14 @@ template<class T> struct is_string;
 template<class T> struct is_writeable_string;
 
 // mark std::span<const char> as a string type
-template<> struct is_string<std::span<const char>> : public std::true_type {};
-template<> struct is_string<const std::span<const char>> : public std::true_type {};
+template<> struct is_string<std::span<const char>>;
+template<> struct is_string<const std::span<const char>>;
 
 // mark std::span<char> as a string type
-template<> struct is_string<std::span<char>> : public std::true_type {};
-template<> struct is_string<const std::span<char>> : public std::true_type {};
-template<> struct is_writeable_string<std::span<char>> : public std::true_type {};
-template<> struct is_writeable_string<const std::span<char>> : public std::true_type {};
+template<> struct is_string<std::span<char>>;
+template<> struct is_string<const std::span<char>>;
+template<> struct is_writeable_string<std::span<char>>;
+template<> struct is_writeable_string<const std::span<char>>;
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/std/std_fwd.hpp
+++ b/src/c4/std/std_fwd.hpp
@@ -1,11 +1,14 @@
 #ifndef _C4_STD_STD_FWD_HPP_
 #define _C4_STD_STD_FWD_HPP_
 
-/** @file std_fwd.hpp includes all c4-std interop fwd files */
+/** @file std_fwd.hpp includes all c4-std interop fwd files
+ * to enable order-independent includes for use with ref @ref
+ * c4::to_chars() and @ref c4::from_chars(). */
 
 #include "c4/std/vector_fwd.hpp"
 #include "c4/std/string_fwd.hpp"
 #include "c4/std/span_fwd.hpp"
+#include "c4/std/string_view_fwd.hpp"
 //#include "c4/std/tuple_fwd.hpp"
 
 #endif // _C4_STD_STD_FWD_HPP_

--- a/src/c4/std/string.hpp
+++ b/src/c4/std/string.hpp
@@ -34,7 +34,7 @@ C4_ALWAYS_INLINE c4::substr to_substr(std::string &s) noexcept
     #error this function will have undefined behavior
     #endif
     // since c++11 it is legal to call s[s.size()].
-    return c4::substr(&s[0], s.size()); // NOLINT(readability-container-data-pointer)
+    return c4::substr(&s[0], s.size()); // NOLINT
 }
 
 /** get a readonly view to an existing std::string.
@@ -48,7 +48,7 @@ C4_ALWAYS_INLINE c4::csubstr to_csubstr(std::string const& s) noexcept
     #error this function will have undefined behavior
     #endif
     // since c++11 it is legal to call s[s.size()].
-    return c4::csubstr(&s[0], s.size()); // NOLINT(readability-container-data-pointer)
+    return c4::csubstr(&s[0], s.size()); // NOLINT
 }
 
 //-----------------------------------------------------------------------------

--- a/src/c4/std/string.hpp
+++ b/src/c4/std/string.hpp
@@ -14,6 +14,7 @@ namespace c4 {
 // mark std::string as a string type
 template<class T> struct is_string;
 template<> struct is_string<std::string> : public std::true_type {};
+template<> struct is_string<const std::string> : public std::true_type {};
 
 // mark std::string as a writeable string type
 template<class T> struct is_writeable_string;

--- a/src/c4/std/string_fwd.hpp
+++ b/src/c4/std/string_fwd.hpp
@@ -33,6 +33,15 @@ C4_SUPPRESS_WARNING_MSVC_POP
 
 namespace c4 {
 
+// mark std::string as a string type
+template<class T> struct is_string;
+template<> struct is_string<std::string>;
+template<> struct is_string<const std::string>;
+
+// mark std::string as a writeable string type
+template<class T> struct is_writeable_string;
+template<> struct is_writeable_string<std::string>;
+
 c4::substr to_substr(std::string &s) noexcept;
 c4::csubstr to_csubstr(std::string const& s) noexcept;
 

--- a/src/c4/std/string_fwd.hpp
+++ b/src/c4/std/string_fwd.hpp
@@ -1,7 +1,9 @@
 #ifndef _C4_STD_STRING_FWD_HPP_
 #define _C4_STD_STRING_FWD_HPP_
 
-/** @file string_fwd.hpp */
+/** @file string_fwd.hpp Provides forward declaration of std::string
+ * to enable order-independent includes for use with ref @ref
+ * c4::to_chars() and @ref c4::from_chars(). */
 
 #ifndef DOXYGEN
 

--- a/src/c4/std/string_view.hpp
+++ b/src/c4/std/string_view.hpp
@@ -21,6 +21,7 @@ namespace c4 {
 // mark std::string_view as a string type
 template<class T> struct is_string;
 template<> struct is_string<std::string_view> : public std::true_type {};
+template<> struct is_string<const std::string_view> : public std::true_type {};
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/std/string_view.hpp
+++ b/src/c4/std/string_view.hpp
@@ -4,13 +4,17 @@
 /** @file string_view.hpp */
 
 #ifndef C4CORE_SINGLE_HEADER
+#ifndef _C4_LANGUAGE_HPP_
 #include "c4/language.hpp"
+#endif
 #endif
 
 #if (C4_CPP >= 17 && defined(__cpp_lib_string_view)) || defined(__DOXYGEN__)
 
 #ifndef C4CORE_SINGLE_HEADER
+#ifndef _C4_SUBSTR_HPP_
 #include "c4/substr.hpp"
+#endif
 #endif
 
 #include <string_view>

--- a/src/c4/std/string_view_fwd.hpp
+++ b/src/c4/std/string_view_fwd.hpp
@@ -22,7 +22,6 @@
 namespace c4 {
 
 template<class T> struct is_string;
-template<class T> struct is_writeable_string;
 
 // mark std::string_view as a string type
 template<> struct is_string<std::string_view>;

--- a/src/c4/std/string_view_fwd.hpp
+++ b/src/c4/std/string_view_fwd.hpp
@@ -1,0 +1,62 @@
+#ifndef _C4_STD_STRING_VIEW_FWD_HPP_
+#define _C4_STD_STRING_VIEW_FWD_HPP_
+
+/** @file string_view_fwd.hpp Provides forward declaration of std::string_view
+ * to enable order-independent includes for use with ref @ref
+ * c4::to_chars() and @ref c4::from_chars(). */
+
+#ifndef C4CORE_SINGLE_HEADER
+#include "c4/language.hpp"
+#endif
+
+
+#if (C4_CPP >= 17) || defined(__DOXYGEN__)
+
+#ifndef C4CORE_SINGLE_HEADER
+#include "c4/substr_fwd.hpp"
+#endif
+
+#include <string_view> // AFAICT it's not possible to fwd-declare std::string_view
+
+
+namespace c4 {
+
+template<class T> struct is_string;
+template<class T> struct is_writeable_string;
+
+// mark std::string_view as a string type
+template<> struct is_string<std::string_view>;
+template<> struct is_string<const std::string_view>;
+
+
+//-----------------------------------------------------------------------------
+
+c4::csubstr to_csubstr(std::string_view s) noexcept;
+
+
+//-----------------------------------------------------------------------------
+
+bool operator== (c4::csubstr ss, std::string_view s);
+bool operator!= (c4::csubstr ss, std::string_view s);
+bool operator>= (c4::csubstr ss, std::string_view s);
+bool operator>  (c4::csubstr ss, std::string_view s);
+bool operator<= (c4::csubstr ss, std::string_view s);
+bool operator<  (c4::csubstr ss, std::string_view s);
+
+bool operator== (std::string_view s, c4::csubstr ss);
+bool operator!= (std::string_view s, c4::csubstr ss);
+bool operator<= (std::string_view s, c4::csubstr ss);
+bool operator<  (std::string_view s, c4::csubstr ss);
+bool operator>= (std::string_view s, c4::csubstr ss);
+bool operator>  (std::string_view s, c4::csubstr ss);
+
+
+//-----------------------------------------------------------------------------
+
+size_t to_chars(c4::substr buf, std::string_view s);
+
+} // namespace c4
+
+#endif // STRING_VIEW_AVAILABLE
+
+#endif // _C4_STD_STRING_VIEW_FWD_HPP_

--- a/src/c4/std/vector.hpp
+++ b/src/c4/std/vector.hpp
@@ -23,6 +23,7 @@ namespace c4 {
 // mark std::string as a string type
 template<class T> struct is_string;
 template<class Alloc> struct is_string<std::vector<char,Alloc>> : public std::true_type {};
+template<class Alloc> struct is_string<const std::vector<char,Alloc>> : public std::true_type {};
 
 // mark std::string as a writeable string type
 template<class T> struct is_writeable_string;

--- a/src/c4/std/vector_fwd.hpp
+++ b/src/c4/std/vector_fwd.hpp
@@ -43,6 +43,12 @@ template<typename T, typename Alloc> class vector;
 
 namespace c4 {
 
+template<class T> struct is_string;
+template<class T> struct is_writeable_string;
+template<class Alloc> struct is_string<std::vector<char,Alloc>>;
+template<class Alloc> struct is_string<const std::vector<char,Alloc>>;
+template<class Alloc> struct is_writeable_string<std::vector<char,Alloc>>;
+
 template<class Alloc> c4::substr to_substr(std::vector<char, Alloc> &vec);
 template<class Alloc> c4::csubstr to_csubstr(std::vector<char, Alloc> const& vec);
 

--- a/src/c4/std/vector_fwd.hpp
+++ b/src/c4/std/vector_fwd.hpp
@@ -1,7 +1,9 @@
 #ifndef _C4_STD_VECTOR_FWD_HPP_
 #define _C4_STD_VECTOR_FWD_HPP_
 
-/** @file vector_fwd.hpp */
+/** @file vector_fwd.hpp Provides forward declaration of std::vector
+ * to enable order-independent includes for use with ref
+ * @ref c4::to_chars() and @ref c4::from_chars(). */
 
 #include <cstddef>
 

--- a/src/c4/std/vector_fwd.hpp
+++ b/src/c4/std/vector_fwd.hpp
@@ -16,13 +16,13 @@ __pragma(warning(push))
 __pragma(warning(disable : 4643))
 #endif
 namespace std {
-template<typename> class allocator;
+template<typename> class allocator; // NOLINT
 #ifdef _GLIBCXX_DEBUG
 inline namespace __debug {
-template<typename T, typename Alloc> class vector;
+template<typename T, typename Alloc> class vector; // NOLINT
 }
 #else
-template<typename T, typename Alloc> class vector;
+template<typename T, typename Alloc> class vector; // NOLINT
 #endif
 } // namespace std
 #if defined(_MSC_VER)
@@ -31,8 +31,8 @@ __pragma(warning(pop))
 #elif defined(_LIBCPP_ABI_NAMESPACE)
 namespace std {
 inline namespace _LIBCPP_ABI_NAMESPACE {
-template<typename> class allocator;
-template<typename T, typename Alloc> class vector;
+template<typename> class allocator; // NOLINT
+template<typename T, typename Alloc> class vector; // NOLINT
 } // namespace _LIBCPP_ABI_NAMESPACE
 } // namespace std
 #else

--- a/src/c4/substr.hpp
+++ b/src/c4/substr.hpp
@@ -297,14 +297,14 @@ public:
      * @warning the input string need not be zero terminated, but the
      * length is taken as if the string was zero terminated */
     template<size_t N>
-    C4_ALWAYS_INLINE void assign(C (&s_)[N]) noexcept { str = (s_); len = (N-1); }
+    C4_ALWAYS_INLINE void assign(C (&s_)[N]) noexcept { str = s_; len = (N-1); }
     /** Assign from a pointer and length.
      * @warning the input string need not be zero terminated. */
     C4_ALWAYS_INLINE void assign(C *s_, size_t len_) noexcept { str = s_; len = len_; C4_ASSERT(str || !len_); }
     /** Assign from two pointers.
      * @warning the end pointer MUST BE larger than or equal to the begin pointer
      * @warning the input string need not be zero terminated. */
-    C4_ALWAYS_INLINE void assign(C *beg_, C *end_) noexcept { C4_ASSERT(end_ >= beg_); str = (beg_); len = static_cast<size_t>(end_ - beg_); }
+    C4_ALWAYS_INLINE void assign(C *beg_, C *end_) noexcept { C4_ASSERT(end_ >= beg_); str = beg_; len = static_cast<size_t>(end_ - beg_); }
     /** Assign from a C-string (zero-terminated string of type const C* or C*)
      * @warning the input string must be zero terminated.
      * @warning will call strlen()
@@ -326,7 +326,7 @@ public:
     /** Assign from an array.
      * @warning the input string need not be zero terminated. */
     template<size_t N>
-    C4_ALWAYS_INLINE basic_substring& operator= (C (&s_)[N]) noexcept { str = (s_); len = (N-1); return *this; }
+    C4_ALWAYS_INLINE basic_substring& operator= (C (&s_)[N]) noexcept { str = s_; len = (N-1); return *this; }
     /** Assign from a C-string (zero-terminated string of type const C* or C*)
      * @warning the input string MUST BE zero terminated.
      * @warning will call strlen()
@@ -885,7 +885,7 @@ public:
         }
         for(size_t i = 0; i < pattern.len; ++i)
         {
-            if(str[i] != pattern[i])
+            if(str[i] != pattern.str[i])
             {
                 return false;
             }
@@ -1003,7 +1003,7 @@ public:
         {
             for(size_t j = 0; j < chars.len; ++j)
             {
-                if(str[i] == chars[j])
+                if(str[i] == chars.str[j])
                     return i;
             }
         }

--- a/src/c4/substr.hpp
+++ b/src/c4/substr.hpp
@@ -19,15 +19,91 @@ C4_SUPPRESS_WARNING_GCC("-Wtype-limits") // disable warnings on size_t>=0, used 
 
 namespace c4 {
 
-/** @defgroup doc_substr Substring: read/write string views
- * @{ */
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
 
 /** @cond dev */
 namespace detail {
+
+// implementation of is_string/is_writeable_string
+template<class T> struct is_string : public std::false_type {};
+template<class T> struct is_writeable_string : public std::false_type {};
+
+template<> struct is_string<char*> : public std::true_type {};
+template<> struct is_writeable_string<char*> : public std::true_type {};
+
+template<> struct is_string<const char*> : public std::true_type {};
+template<> struct is_writeable_string<const char*> : public std::false_type {};
+
+template<size_t N> struct is_string<const char[N]> : public std::true_type {};
+template<size_t N> struct is_writeable_string<const char[N]> : public std::false_type {};
+
+template<size_t N> struct is_string<char[N]> : public std::true_type {};
+template<size_t N> struct is_writeable_string<char[N]> : public std::true_type {};
+
+template<size_t N> struct is_string<const char (&)[N]> : public std::true_type {};
+template<size_t N> struct is_writeable_string<const char (&)[N]> : public std::false_type {};
+
+template<size_t N> struct is_string<char (&)[N]> : public std::true_type {};
+template<size_t N> struct is_writeable_string<char (&)[N]> : public std::true_type {};
+
+template<size_t N> struct is_string<const char (&&)[N]> : public std::true_type {};
+template<size_t N> struct is_writeable_string<const char (&&)[N]> : public std::false_type {};
+
+template<size_t N> struct is_string<char (&&)[N]> : public std::true_type {};
+template<size_t N> struct is_writeable_string<char (&&)[N]> : public std::true_type {};
+
+
+// utility trait to remove restrict keyword
+template<class T> struct remove_restrict { using type = T; };
+template<class T> struct remove_restrict<T *C4_RESTRICT> { using type = T*; };
+template<class T> struct remove_restrict<T &C4_RESTRICT> { using type = T&; }; // clang<8 does not match this!!!
+// utility trait to remove references from pointer reference
+template<class T> struct remove_ptrref { using type = T; };
+template<class T> struct remove_ptrref<T*&> { using type = T*; };
+template<class T> struct remove_ptrref<T* const&> { using type = T* const; };
+template<class T> struct remove_ptrref<T* C4_RESTRICT &> { using type = T *C4_RESTRICT; };
+template<class T> struct remove_ptrref<T* C4_RESTRICT const&> { using type = T *C4_RESTRICT const; };
+// utility trait to remove const, but only from pointer types
+template<class T> struct remove_ptrconst { using type = T; };
+template<class T> struct remove_ptrconst<T *const> { using type = T*; };
+template<class T> struct remove_ptrconst<T *C4_RESTRICT const> { using type = T* C4_RESTRICT; };
+
+
+// clean a type of qualifiers for enabling
+// SFINAE on raw-pointer types irrespective of the qualifiers.
+template<class T>
+struct bare_pointer_type
+{
+    using type = typename remove_restrict<
+        typename remove_ptrconst<
+            typename remove_ptrref<
+                T>::type
+            >::type
+        >::type;
+};
+
+
+template<class FromPointerTypeBare, class ToValueType>
+struct _is_comp_char_ptr : std::integral_constant<
+    bool,
+    std::is_same<FromPointerTypeBare,
+                 typename std::remove_const<ToValueType>::type *>::value
+    ||
+    std::is_same<FromPointerTypeBare,
+                 ToValueType const*>::value> {};
+
+
+template<class FromPointerTypeBare, class ToValueType>
+struct _can_borrow_char_ptr : std::integral_constant<
+    bool,
+    _is_comp_char_ptr<FromPointerTypeBare, ToValueType>::value
+    &&
+    (
+        std::is_const<ToValueType>::value
+        ||
+        ! std::is_const<typename std::remove_pointer<FromPointerTypeBare>::type>::value
+    )> {};
+
+
 template<typename C>
 static inline void _do_reverse(C *C4_RESTRICT first, C *C4_RESTRICT last)
 {
@@ -39,20 +115,86 @@ static inline void _do_reverse(C *C4_RESTRICT first, C *C4_RESTRICT last)
     }
 }
 } // namespace detail
-/** @endcond */
-
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-
-/** @cond dev */
 // utility macros to deuglify SFINAE code; undefined after the class.
 // https://stackoverflow.com/questions/43051882/how-to-disable-a-class-member-funrtion-for-certain-template-types
 #define C4_REQUIRE_RW(ret_type) \
     template <typename U=C> \
     typename std::enable_if< ! std::is_const<U>::value, ret_type>::type
 /** @endcond */
+
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+/** @defgroup string_traits String traits classes
+ * @{ */
+
+/** a traits class to mark a type as a string type, meaning @ref
+ * c4::to_csubstr() can be used directly instead of @ref
+ * c4::to_chars() when formatting the string. */
+template<class T> struct is_string
+    : public detail::is_string<
+        typename detail::bare_pointer_type<T>::type
+      > {};
+
+
+/** a traits class to mark a type as a writeable string type, meaning
+ * @ref c4::to_substr() can be used directly instead of @ref
+ * c4::from_chars() when reading the string. */
+template<class T> struct is_writeable_string
+    : public detail::is_writeable_string<
+        typename detail::bare_pointer_type<T>::type
+      > {};
+
+
+template<typename C> struct is_string<basic_substring<C>> : public std::true_type {};
+template<> struct is_string<const basic_substring<char>> : public std::true_type {};
+template<> struct is_string<const basic_substring<const char>> : public std::true_type {};
+template<> struct is_writeable_string<basic_substring<char>> : public std::true_type {};
+template<> struct is_writeable_string<const basic_substring<char>> : public std::true_type {};
+
+
+/* traits class to query whether a pointer-type stripped of qualifiers
+ * like volatile or C4_RESTRICT is one of char* or const char*,
+ * compatible with a destination value type (one of char or const
+ * char).
+ *
+ * This is used to enable SFINAE on char* and const char* overloads
+ * for use with substr/csubstr. FromPointerType is the SFINAE-d type,
+ * and ToValueType is the char or const char destination type. See
+ * @ref c4::basic_substring below for examples of usage. */
+template<class FromPointerType, class ToValueType>
+struct is_compatible_char_ptr
+    : detail::_is_comp_char_ptr<
+        typename detail::bare_pointer_type<FromPointerType>::type,
+        ToValueType> {};
+
+
+/* traits class to query whether a pointer-type stripped of qualifiers
+ * like volatile or C4_RESTRICT is one of char* or const char*,
+ * compatible with a destination value type (one of char or const
+ * char) and further can be used to initialize a substring.
+ *
+ * This is used to enable SFINAE on char* and const char* overloads
+ * for use with substr/csubstr. FromPointerType is the SFINAE-d type,
+ * and ToValueType is the char or const char destination type. See
+ * @ref c4::basic_substring below for examples of usage. */
+template<class FromPointerType, class ToValueType>
+struct can_borrow_char_ptr
+    : detail::_can_borrow_char_ptr<
+        typename detail::bare_pointer_type<FromPointerType>::type,
+        ToValueType> {};
+
+/** @} */
+
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+/** @defgroup doc_substr Substring: read/write string views
+ * @{ */
 
 
 /** a non-owning string-view, consisting of a character pointer
@@ -85,6 +227,7 @@ public:
     using ro_substr = basic_substring<CC>;
     using rw_substr = basic_substring<NCC_>;
 
+    using value_type = C;
     using char_type = C;
     using size_type = size_t;
 
@@ -93,9 +236,10 @@ public:
 
     enum : size_t { npos = (size_t)-1, NONE = (size_t)-1 };
 
-    /// convert automatically to substring of const C
+    /// convert automatically from substr (of C) to csubstr (of const C)
     template<class U=C>
-    C4_ALWAYS_INLINE operator typename std::enable_if<!std::is_const<U>::value, ro_substr const&>::type () const noexcept
+    C4_ALWAYS_INLINE operator
+    typename std::enable_if<!std::is_const<U>::value, ro_substr const&>::type () const noexcept
     {
         return *(ro_substr const*)this; // don't call the str+len ctor because it does a check
     }
@@ -144,8 +288,9 @@ public:
      * @note this overload uses SFINAE to prevent it from overriding the array ctor
      * @see For a more detailed explanation on why the plain overloads cannot
      * coexist, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
-    template<class U, typename std::enable_if<std::is_same<U, C*>::value || std::is_same<U, NCC_*>::value, int>::type=0>
-    C4_ALWAYS_INLINE basic_substring(U s_) noexcept : str(s_), len(s_ ? strlen(s_) : 0) {}
+    template<class CharPtr, typename std::enable_if<can_borrow_char_ptr<CharPtr, C>::value, int>::type=0>
+    C4_ALWAYS_INLINE basic_substring(CharPtr s_) noexcept : str(s_), len(s_ ? strlen(s_) : 0) {}
+
 
     /** Assign from an array.
      * @warning the input string need not be zero terminated, but the
@@ -162,11 +307,20 @@ public:
     /** Assign from a C-string (zero-terminated string of type const C* or C*)
      * @warning the input string must be zero terminated.
      * @warning will call strlen()
-     * @note this overload uses SFINAE to prevent it from overriding the array ctor
+     * @note this overload uses SFINAE to prevent it from overriding the array assignment
      * @see For a more detailed explanation on why the plain pointer overloads cannot
      * coexist with the array overloads, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
-    template<class U, typename std::enable_if<std::is_same<U, C*>::value || std::is_same<U, NCC_*>::value, int>::type=0>
-    C4_ALWAYS_INLINE void assign(U s_) noexcept { str = (s_); len = (s_ ? strlen(s_) : 0); }
+    template<class CharPtr, typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type=0>
+    C4_ALWAYS_INLINE void assign(CharPtr s_) noexcept
+    {
+        // the SFINAE is catching const types, so that on calls like
+        // s.assign(const char*) we can do a static_assert, and so
+        // the user will see an informative error message
+        static_assert(can_borrow_char_ptr<CharPtr, C>::value, "string pointer is not mutable");
+        str = s_;
+        len = (s_ ? strlen(s_) : 0);
+    }
+
 
     /** Assign from an array.
      * @warning the input string need not be zero terminated. */
@@ -175,11 +329,20 @@ public:
     /** Assign from a C-string (zero-terminated string of type const C* or C*)
      * @warning the input string MUST BE zero terminated.
      * @warning will call strlen()
-     * @note this overload uses SFINAE to prevent it from overriding the array ctor
+     * @note this overload uses SFINAE to prevent it from overriding the array assignment
      * @see For a more detailed explanation on why the plain pointer overloads cannot
      * coexist with the array overloads, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
-    template<class U, typename std::enable_if<std::is_same<U, C*>::value || std::is_same<U, NCC_*>::value, int>::type=0>
-    C4_ALWAYS_INLINE basic_substring& operator= (U s_) noexcept { str = s_; len = s_ ? strlen(s_) : 0; return *this; }
+    template<class CharPtr, typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type=0>
+    C4_ALWAYS_INLINE basic_substring& operator= (CharPtr s_) noexcept
+    {
+        // the SFINAE is catching const types, so that on calls like
+        // substr(const char*) we can do a static_assert, and so
+        // the user will see an informative error message
+        static_assert(can_borrow_char_ptr<CharPtr, C>::value, "string pointer is not mutable");
+        str = s_;
+        len = s_ ? strlen(s_) : 0;
+        return *this;
+    }
 
     /** @} */
 
@@ -260,7 +423,18 @@ public:
         #endif
     }
 
-    C4_ALWAYS_INLINE C4_PURE int compare(ro_substr const that) const noexcept { return this->compare(that.str, that.len); }
+    template<class CharPtr>
+    C4_ALWAYS_INLINE C4_PURE auto compare(CharPtr c_str) const noexcept
+        -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type
+    {
+        return compare(c_str, strlen(c_str));
+    }
+
+    template<class U>
+    C4_ALWAYS_INLINE C4_PURE int compare(basic_substring<U> const that) const noexcept
+    {
+        return this->compare(that.str, that.len);
+    }
 
     C4_ALWAYS_INLINE C4_PURE bool operator== (std::nullptr_t) const noexcept { return str == nullptr; }
     C4_ALWAYS_INLINE C4_PURE bool operator!= (std::nullptr_t) const noexcept { return str != nullptr; }
@@ -279,12 +453,19 @@ public:
     template<class U> C4_ALWAYS_INLINE C4_PURE bool operator<= (basic_substring<U> const that) const noexcept { return this->compare(that) <= 0; }
     template<class U> C4_ALWAYS_INLINE C4_PURE bool operator>= (basic_substring<U> const that) const noexcept { return this->compare(that) >= 0; }
 
-    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator== (const char (&that)[N]) const noexcept { return this->compare(that, N-1) == 0; }
-    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator!= (const char (&that)[N]) const noexcept { return this->compare(that, N-1) != 0; }
-    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator<  (const char (&that)[N]) const noexcept { return this->compare(that, N-1) <  0; }
-    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator>  (const char (&that)[N]) const noexcept { return this->compare(that, N-1) >  0; }
-    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator<= (const char (&that)[N]) const noexcept { return this->compare(that, N-1) <= 0; }
-    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator>= (const char (&that)[N]) const noexcept { return this->compare(that, N-1) >= 0; }
+    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator== (const char (&arr)[N]) const noexcept { return this->compare(arr, N-1) == 0; }
+    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator!= (const char (&arr)[N]) const noexcept { return this->compare(arr, N-1) != 0; }
+    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator<  (const char (&arr)[N]) const noexcept { return this->compare(arr, N-1) <  0; }
+    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator>  (const char (&arr)[N]) const noexcept { return this->compare(arr, N-1) >  0; }
+    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator<= (const char (&arr)[N]) const noexcept { return this->compare(arr, N-1) <= 0; }
+    template<size_t N> C4_ALWAYS_INLINE C4_PURE bool operator>= (const char (&arr)[N]) const noexcept { return this->compare(arr, N-1) >= 0; }
+
+    template<class CharPtr> C4_ALWAYS_INLINE C4_PURE auto operator== (CharPtr c_str) const noexcept -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type{ return this->compare(c_str, strlen(c_str)) == 0; }
+    template<class CharPtr> C4_ALWAYS_INLINE C4_PURE auto operator!= (CharPtr c_str) const noexcept -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type{ return this->compare(c_str, strlen(c_str)) != 0; }
+    template<class CharPtr> C4_ALWAYS_INLINE C4_PURE auto operator<  (CharPtr c_str) const noexcept -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type{ return this->compare(c_str, strlen(c_str)) <  0; }
+    template<class CharPtr> C4_ALWAYS_INLINE C4_PURE auto operator>  (CharPtr c_str) const noexcept -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type{ return this->compare(c_str, strlen(c_str)) >  0; }
+    template<class CharPtr> C4_ALWAYS_INLINE C4_PURE auto operator<= (CharPtr c_str) const noexcept -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type{ return this->compare(c_str, strlen(c_str)) <= 0; }
+    template<class CharPtr> C4_ALWAYS_INLINE C4_PURE auto operator>= (CharPtr c_str) const noexcept -> typename std::enable_if<is_compatible_char_ptr<CharPtr, C>::value, int>::type{ return this->compare(c_str, strlen(c_str)) >= 0; }
 
     /** @} */
 
@@ -2071,7 +2252,7 @@ public:
 public:
 
     /** erase part of the string. eg, with char s[] = "0123456789",
-     * substr(s).erase(3, 2) = "01256789", and s is now "01245678989"
+     * substr(s).erase(3, 2) = "01256789", and s is now "0125678989"
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
     C4_REQUIRE_RW(basic_substring) erase(size_t pos, size_t num)
     {
@@ -2192,9 +2373,10 @@ public:
 
 /** @defgroup doc_substr_adapters substr adapters
  *
- * to_substr() and to_csubstr() is used in generic code like
- * format(), and allow adding construction of substrings from new
- * types like containers.
+ * @ref c4::to_substr() and @ref c4::to_csubstr() are used in generic
+ * code like @ref c4::format(). They enable the user to provide an
+ * entry point for the construction of substrings from custom types
+ *
  * @{ */
 
 
@@ -2206,68 +2388,38 @@ C4_ALWAYS_INLINE csubstr to_csubstr(substr s) noexcept { return csubstr{s.str, s
 C4_ALWAYS_INLINE csubstr to_csubstr(csubstr s) noexcept { return s; }
 
 
+/** neutral version for use in generic code */
 template<size_t N> C4_ALWAYS_INLINE substr to_substr(char (&s)[N]) noexcept
 {
     return substr(s, N-1);
 }
+
 template<size_t N> C4_ALWAYS_INLINE csubstr to_csubstr(const char (&s)[N]) noexcept
 {
     return csubstr(s, N-1);
 }
 
 
-/** @note this overload uses SFINAE to prevent it from overriding the array overload
+/** Create a substring from a char*-like pointer
+ * @note this overload uses SFINAE to prevent it from overriding the array overload
  * @see For a more detailed explanation on why the plain overloads cannot
  * coexist, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
 template<class U> C4_ALWAYS_INLINE auto to_substr(U s) noexcept
-    -> typename std::enable_if<std::is_same<U, char*>::value, substr>::type
+    -> typename std::enable_if<is_compatible_char_ptr<U, char>::value, substr>::type
 {
     return substr(s);
 }
-/** @note this overload uses SFINAE to prevent it from overriding the array overload
+
+/** Create a substring from a const char*-like pointer
+ *
+ * @note this overload uses SFINAE to prevent it from overriding the array overload
  * @see For a more detailed explanation on why the plain overloads cannot
  * coexist, see http://cplusplus.bordoon.com/specializeForCharacterArrays.html */
 template<class U> C4_ALWAYS_INLINE auto to_csubstr(U s) noexcept
-    -> typename std::enable_if<std::is_same<U, const char*>::value || std::is_same<U, char*>::value, csubstr>::type
+    -> typename std::enable_if<is_compatible_char_ptr<U, const char>::value, csubstr>::type
 {
     return csubstr(s);
 }
-
-
-/** a traits class to mark a type as a string type
- * (meaning @ref c4::to_csubstr() can be used directly). */
-template<class T> struct is_string : public std::false_type {};
-/** a traits class to mark a type as a writeable string type
- * (meaning @ref c4::to_substr() can be used directly). */
-template<class T> struct is_writeable_string : public std::false_type {};
-
-template<typename C> struct is_string<basic_substring<C>> : public std::true_type {};
-template<> struct is_writeable_string<basic_substring<char>> : public std::true_type {};
-template<> struct is_writeable_string<basic_substring<const char>> : public std::false_type {};
-
-template<> struct is_string<const char*> : public std::true_type {};
-template<> struct is_writeable_string<const char*> : public std::false_type {};
-
-template<> struct is_string<char*> : public std::true_type {};
-template<> struct is_writeable_string<char*> : public std::true_type {};
-
-template<size_t N> struct is_string<const char[N]> : public std::true_type {};
-template<size_t N> struct is_writeable_string<const char[N]> : public std::false_type {};
-
-template<size_t N> struct is_string<char[N]> : public std::true_type {};
-template<size_t N> struct is_writeable_string<char[N]> : public std::true_type {};
-
-template<size_t N> struct is_string<const char (&)[N]> : public std::true_type {};
-template<size_t N> struct is_writeable_string<const char (&)[N]> : public std::false_type {};
-
-template<size_t N> struct is_string<char (&)[N]> : public std::true_type {};
-template<size_t N> struct is_writeable_string<char (&)[N]> : public std::true_type {};
-
-template<size_t N> struct is_string<const char (&&)[N]> : public std::true_type {};
-template<size_t N> struct is_writeable_string<const char (&&)[N]> : public std::false_type {};
-
-template<size_t N> struct is_string<char (&&)[N]> : public std::true_type {};
-template<size_t N> struct is_writeable_string<char (&&)[N]> : public std::true_type {};
 
 /** @} */
 
@@ -2279,19 +2431,33 @@ template<size_t N> struct is_writeable_string<char (&&)[N]> : public std::true_t
 /** @defgroup doc_substr_cmp substr comparison operators
  * @{ */
 
-template<typename C, size_t N> inline bool operator== (const char (&s)[N], basic_substring<C> const that) noexcept { return that.compare(s, N-1) == 0; }
-template<typename C, size_t N> inline bool operator!= (const char (&s)[N], basic_substring<C> const that) noexcept { return that.compare(s, N-1) != 0; }
-template<typename C, size_t N> inline bool operator<  (const char (&s)[N], basic_substring<C> const that) noexcept { return that.compare(s, N-1) >  0; }
-template<typename C, size_t N> inline bool operator>  (const char (&s)[N], basic_substring<C> const that) noexcept { return that.compare(s, N-1) <  0; }
-template<typename C, size_t N> inline bool operator<= (const char (&s)[N], basic_substring<C> const that) noexcept { return that.compare(s, N-1) >= 0; }
-template<typename C, size_t N> inline bool operator>= (const char (&s)[N], basic_substring<C> const that) noexcept { return that.compare(s, N-1) <= 0; }
-
+/** @name single character @{ */
 template<typename C> inline bool operator== (const char c, basic_substring<C> const that) noexcept { return that.compare(c) == 0; }
 template<typename C> inline bool operator!= (const char c, basic_substring<C> const that) noexcept { return that.compare(c) != 0; }
 template<typename C> inline bool operator<  (const char c, basic_substring<C> const that) noexcept { return that.compare(c) >  0; }
 template<typename C> inline bool operator>  (const char c, basic_substring<C> const that) noexcept { return that.compare(c) <  0; }
 template<typename C> inline bool operator<= (const char c, basic_substring<C> const that) noexcept { return that.compare(c) >= 0; }
 template<typename C> inline bool operator>= (const char c, basic_substring<C> const that) noexcept { return that.compare(c) <= 0; }
+/** @} */
+
+/** @name character array/literal @{ */
+template<typename C, size_t N> inline bool operator== (const char (&arr)[N], basic_substring<C> const that) noexcept { return that.compare(arr, N-1) == 0; }
+template<typename C, size_t N> inline bool operator!= (const char (&arr)[N], basic_substring<C> const that) noexcept { return that.compare(arr, N-1) != 0; }
+template<typename C, size_t N> inline bool operator<  (const char (&arr)[N], basic_substring<C> const that) noexcept { return that.compare(arr, N-1) >  0; }
+template<typename C, size_t N> inline bool operator>  (const char (&arr)[N], basic_substring<C> const that) noexcept { return that.compare(arr, N-1) <  0; }
+template<typename C, size_t N> inline bool operator<= (const char (&arr)[N], basic_substring<C> const that) noexcept { return that.compare(arr, N-1) >= 0; }
+template<typename C, size_t N> inline bool operator>= (const char (&arr)[N], basic_substring<C> const that) noexcept { return that.compare(arr, N-1) <= 0; }
+/** @} */
+
+/** @name C string (character pointer, zero terminated)
+ * @{ */
+template<typename U, typename C> inline auto operator== (U c_str, basic_substring<C> const that) noexcept -> typename std::enable_if<is_compatible_char_ptr<U, C>::value, bool>::type { return that.compare(c_str, strlen(c_str)) == 0; }
+template<typename U, typename C> inline auto operator!= (U c_str, basic_substring<C> const that) noexcept -> typename std::enable_if<is_compatible_char_ptr<U, C>::value, bool>::type { return that.compare(c_str, strlen(c_str)) != 0; }
+template<typename U, typename C> inline auto operator<  (U c_str, basic_substring<C> const that) noexcept -> typename std::enable_if<is_compatible_char_ptr<U, C>::value, bool>::type { return that.compare(c_str, strlen(c_str)) >  0; }
+template<typename U, typename C> inline auto operator>  (U c_str, basic_substring<C> const that) noexcept -> typename std::enable_if<is_compatible_char_ptr<U, C>::value, bool>::type { return that.compare(c_str, strlen(c_str)) <  0; }
+template<typename U, typename C> inline auto operator<= (U c_str, basic_substring<C> const that) noexcept -> typename std::enable_if<is_compatible_char_ptr<U, C>::value, bool>::type { return that.compare(c_str, strlen(c_str)) >= 0; }
+template<typename U, typename C> inline auto operator>= (U c_str, basic_substring<C> const that) noexcept -> typename std::enable_if<is_compatible_char_ptr<U, C>::value, bool>::type { return that.compare(c_str, strlen(c_str)) <= 0; }
+/** @} */
 
 /** @} */
 
@@ -2304,14 +2470,8 @@ template<typename C> inline bool operator>= (const char c, basic_substring<C> co
  * template operator<<
  * @see https://github.com/onqtam/doctest/pull/431 */
 #ifndef C4_SUBSTR_NO_OSTREAM_LSHIFT
-#ifdef __clang__
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wsign-conversion"
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
 
+C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wsign-conversion")
 /** output the string to a stream */
 template<class OStream, class C>
 inline OStream& operator<< (OStream& os, basic_substring<C> s)
@@ -2319,20 +2479,8 @@ inline OStream& operator<< (OStream& os, basic_substring<C> s)
     os.write(s.str, s.len);
     return os;
 }
+C4_SUPPRESS_WARNING_GCC_CLANG_POP
 
-// this causes ambiguity
-///** this is used by google test */
-//template<class OStream, class C>
-//inline void PrintTo(basic_substring<C> s, OStream* os)
-//{
-//    os->write(s.str, s.len);
-//}
-
-#ifdef __clang__
-#   pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic pop
-#endif
 #endif // !C4_SUBSTR_NO_OSTREAM_LSHIFT
 
 /** @} */

--- a/src/c4/substr.hpp
+++ b/src/c4/substr.hpp
@@ -105,7 +105,7 @@ struct _can_borrow_char_ptr : std::integral_constant<
 
 
 template<typename C>
-static inline void _do_reverse(C *C4_RESTRICT first, C *C4_RESTRICT last)
+static inline void _do_reverse(C *C4_RESTRICT first, C *C4_RESTRICT last) noexcept
 {
     while(last > first)
     {
@@ -115,11 +115,6 @@ static inline void _do_reverse(C *C4_RESTRICT first, C *C4_RESTRICT last)
     }
 }
 } // namespace detail
-// utility macros to deuglify SFINAE code; undefined after the class.
-// https://stackoverflow.com/questions/43051882/how-to-disable-a-class-member-funrtion-for-certain-template-types
-#define C4_REQUIRE_RW(ret_type) \
-    template <typename U=C> \
-    typename std::enable_if< ! std::is_const<U>::value, ret_type>::type
 /** @endcond */
 
 
@@ -156,14 +151,16 @@ template<> struct is_writeable_string<const basic_substring<char>> : public std:
 
 
 /* traits class to query whether a pointer-type stripped of qualifiers
- * like volatile or C4_RESTRICT is one of char* or const char*,
- * compatible with a destination value type (one of char or const
- * char).
+ * like `C4_RESTRICT` is one of `char*` or `const char*`, compatible
+ * with a destination value type (one of char or const char).
  *
- * This is used to enable SFINAE on char* and const char* overloads
- * for use with substr/csubstr. FromPointerType is the SFINAE-d type,
- * and ToValueType is the char or const char destination type. See
- * @ref c4::basic_substring below for examples of usage. */
+ * This is used in @ref c4::basic_substring to enable SFINAE on
+ * `char*` and `const char*` overloads and prevent these of overriding
+ * coexisting array overloads.
+ *
+ * FromPointerType is the SFINAE-d type, and ToValueType is the char
+ * or const char destination type. See @ref c4::basic_substring below
+ * for examples of usage. */
 template<class FromPointerType, class ToValueType>
 struct is_compatible_char_ptr
     : detail::_is_comp_char_ptr<
@@ -172,14 +169,18 @@ struct is_compatible_char_ptr
 
 
 /* traits class to query whether a pointer-type stripped of qualifiers
- * like volatile or C4_RESTRICT is one of char* or const char*,
+ * like or `C4_RESTRICT` is one of `char*` or `const char*`,
  * compatible with a destination value type (one of char or const
- * char) and further can be used to initialize a substring.
+ * char) and further can be used to initialize a substring of that
+ * destination value type.
  *
- * This is used to enable SFINAE on char* and const char* overloads
- * for use with substr/csubstr. FromPointerType is the SFINAE-d type,
- * and ToValueType is the char or const char destination type. See
- * @ref c4::basic_substring below for examples of usage. */
+ * This is used in @ref c4::basic_substring to enable SFINAE on
+ * `char*` and `const char*` overloads and prevent these of overriding
+ * coexisting array overloads.
+ *
+ * FromPointerType is the SFINAE-d type, and ToValueType is the char
+ * or const char destination type. See @ref c4::basic_substring below
+ * for examples of usage. */
 template<class FromPointerType, class ToValueType>
 struct can_borrow_char_ptr
     : detail::_can_borrow_char_ptr<
@@ -2161,7 +2162,9 @@ public:
 
     /** convert the string to upper-case
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) toupper()
+    template<typename U=C>
+    auto toupper()
+        -> typename std::enable_if< ! std::is_const<U>::value, void>::type
     {
         for(size_t i = 0; i < len; ++i)
         {
@@ -2171,7 +2174,9 @@ public:
 
     /** convert the string to lower-case
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) tolower()
+    template<typename U=C>
+    auto tolower()
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         for(size_t i = 0; i < len; ++i)
         {
@@ -2183,7 +2188,9 @@ public:
 
     /** fill the entire contents with the given @p val
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) fill(C val)
+    template<typename U=C>
+    auto fill(C val)
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         for(size_t i = 0; i < len; ++i)
             str[i] = val;
@@ -2193,7 +2200,9 @@ public:
 
     /** copy a string to this substr, starting at 0
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) copy_from(ro_substr that)
+    template<typename U=C>
+    auto copy_from(ro_substr that)
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         C4_ASSERT(!overlaps(that));
         size_t num = that.len <= len ? that.len : len;
@@ -2206,7 +2215,9 @@ public:
 
     /** copy a string to this substr, starting at a specified given position
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) copy_from(ro_substr that, size_t ifirst, size_t num=npos)
+    template<typename U=C>
+    auto copy_from(ro_substr that, size_t ifirst, size_t num=npos)
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         C4_ASSERT(ifirst >= 0 && ifirst <= len);
         num = num != npos ? num : len - ifirst;
@@ -2223,7 +2234,9 @@ public:
 
     /** reverse in place
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) reverse()
+    template<typename U=C>
+    auto reverse()
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         if(len == 0) return;
         detail::_do_reverse(str, str + len - 1);
@@ -2231,7 +2244,9 @@ public:
 
     /** revert a subpart in place
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) reverse_sub(size_t ifirst, size_t num)
+    template<typename U=C>
+    auto reverse_sub(size_t ifirst, size_t num)
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         C4_ASSERT(ifirst >= 0 && ifirst <= len);
         C4_ASSERT(ifirst + num >= 0 && ifirst + num <= len);
@@ -2241,7 +2256,9 @@ public:
 
     /** revert a range in place
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(void) reverse_range(size_t ifirst, size_t ilast)
+    template<typename U=C>
+    auto reverse_range(size_t ifirst, size_t ilast)
+        -> typename std::enable_if< !std::is_const<U>::value, void>::type
     {
         C4_ASSERT(ifirst >= 0 && ifirst <= len);
         C4_ASSERT(ilast  >= 0 && ilast  <= len);
@@ -2254,7 +2271,9 @@ public:
     /** erase part of the string. eg, with char s[] = "0123456789",
      * substr(s).erase(3, 2) = "01256789", and s is now "0125678989"
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(basic_substring) erase(size_t pos, size_t num)
+    template<typename U=C>
+    auto erase(size_t pos, size_t num)
+        -> typename std::enable_if< !std::is_const<U>::value, basic_substring>::type
     {
         C4_ASSERT(pos >= 0 && pos+num <= len);
         size_t num_to_move = len - pos - num;
@@ -2263,7 +2282,9 @@ public:
     }
 
     /** @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(basic_substring) erase_range(size_t first, size_t last)
+    template<typename U=C>
+    auto erase_range(size_t first, size_t last)
+        -> typename std::enable_if< !std::is_const<U>::value, basic_substring>::type
     {
         C4_ASSERT(first <= last);
         return erase(first, static_cast<size_t>(last-first)); // NOLINT
@@ -2272,7 +2293,9 @@ public:
     /** erase a part of the string.
      * @note @p sub must be a substring of this string
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(basic_substring) erase(ro_substr sub)
+    template<typename U=C>
+    auto erase(ro_substr sub)
+        -> typename std::enable_if< !std::is_const<U>::value, basic_substring>::type
     {
         C4_ASSERT(is_super(sub));
         C4_ASSERT(sub.str >= str);
@@ -2284,7 +2307,9 @@ public:
     /** replace every occurrence of character @p value with the character @p repl
      * @return the number of characters that were replaced
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(size_t) replace(C value, C repl, size_t pos=0)
+    template<typename U=C>
+    auto replace(C value, C repl, size_t pos=0)
+        -> typename std::enable_if< ! std::is_const<U>::value, size_t>::type
     {
         C4_ASSERT((pos >= 0 && pos <= len) || pos == npos);
         size_t did_it = 0;
@@ -2300,7 +2325,9 @@ public:
      * the character @p repl.
      * @return the number of characters that were replaced
      * @note this method requires that the string memory is writeable and is SFINAEd out for const C */
-    C4_REQUIRE_RW(size_t) replace(ro_substr chars, C repl, size_t pos=0)
+    template<typename U=C>
+    auto replace(ro_substr chars, C repl, size_t pos=0)
+        -> typename std::enable_if< ! std::is_const<U>::value, size_t>::type
     {
         C4_ASSERT((pos >= 0 && pos <= len) || pos == npos);
         size_t did_it = 0;
@@ -2362,8 +2389,6 @@ public:
     /** @} */
 
 }; // template class basic_substring
-
-#undef C4_REQUIRE_RW
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/type_name.hpp
+++ b/src/c4/type_name.hpp
@@ -3,38 +3,46 @@
 
 /** @file type_name.hpp compile-time type name */
 
-#include "c4/span.hpp"
-#include "c4/compiler.hpp"
+#include <stddef.h>
+#include "c4/language.hpp"
 
 /// @cond dev
-struct _c4t
+// this is an abbreviated way of getting the type name,
+// hence the terse and non-namespaced names
+struct c4t_
 {
     const char *str;
     size_t sz;
-    template<size_t N>
-    constexpr _c4t(const char (&s)[N]) : str(s), sz(N-1) {} // take off the \0
+    template<size_t N> C4_ALWAYS_INLINE constexpr
+    c4t_(const char (&s)[N]) noexcept : str(s), sz(N-1) {} // take off the \0
 };
-// this is a more abbreviated way of getting the type name
-// (if we used span in the return type, the name would involve
-// templates and would create longer type name strings,
-// as well as larger differences between compilers)
 template<class T>
-C4_CONSTEXPR14 C4_ALWAYS_INLINE
-_c4t _c4tn()
+#if !defined(__GNUC__) || (__GNUC__ >= 5) || (C4_CPP >= 14)
+constexpr
+#endif
+C4_ALWAYS_INLINE c4t_ c4tn_()
 {
-    return _c4t(C4_PRETTY_FUNC);
+    return c4t_(C4_PRETTY_FUNC);
 }
 /// @endcond
 
 
 namespace c4 {
 
+/** A non-zero terminated typename string. We're not using csubstr or
+ * span to spare the heavy include. */
+struct C4CORE_EXPORT TypeNameStr
+{
+    const char* str;
+    size_t len;
+};
+
 /** compile-time type name
  * @see http://stackoverflow.com/a/20170989/5875572 */
 template<class T>
-C4_CONSTEXPR14 cspan<char> type_name()
+C4_CONSTEXPR14 TypeNameStr type_name() noexcept
 {
-    const _c4t p = _c4tn<T>();
+    const c4t_ p(c4tn_<T>());
 
 #if (0) // enable this to debug and find the offsets
     for(size_t index = 0; index < p.sz; ++index)
@@ -43,35 +51,39 @@ C4_CONSTEXPR14 cspan<char> type_name()
     for(size_t index = 0; index < p.sz; ++index)
         printf(" %2zu", index);
     printf("\n");
+    for(size_t index = 0; index < p.sz; ++index)
+        printf(" %2zu", p.sz - index);
+    printf("\n");
 #endif
 
 #if defined(_MSC_VER)
 #   if defined(__clang__) // Visual Studio has the clang toolset
 #       if (_MSC_VER >= 1930) // do not use this: defined(C4_MSVC_2022)
     // ..............................xxx.
-    // _c4t __cdecl _c4tn(void) [T = int]
+    // c4t_ __cdecl c4tn_(void) [T = int]
     enum : size_t { tstart = 30, tend = 1};
 #       else
     // example:
     // ..........................xxx.
-    // _c4t __cdecl _c4tn() [T = int]
+    // c4t_ __cdecl c4tn_() [T = int]
     enum : size_t { tstart = 26, tend = 1};
 #       endif
 #   elif (_MSC_VER >= 1900)
     // Note: subtract 7 at the end because the function terminates with ">(void)" in VS2015+
-    cspan<char>::size_type tstart = 26, tend = 7;
+    size_t tstart = 26, tend = 7;
 
     const char *C4_RESTRICT s = p.str + tstart; // look at the start
+    size_t sz = p.sz - tstart;
 
     // we're not using strcmp() or memcmp() to spare the #include
 
     // does it start with 'class '?
-    if(p.sz > 6 && s[0] == 'c' && s[1] == 'l' && s[2] == 'a' && s[3] == 's' && s[4] == 's' && s[5] == ' ')
+    if(sz > 6 && s[0] == 'c' && s[1] == 'l' && s[2] == 'a' && s[3] == 's' && s[4] == 's' && s[5] == ' ')
     {
         tstart += 6;
     }
     // does it start with 'struct '?
-    else if(p.sz > 7 && s[0] == 's' && s[1] == 't' && s[2] == 'r' && s[3] == 'u' && s[4] == 'c' && s[5] == 't' && s[6] == ' ')
+    else if(sz > 7 && s[0] == 's' && s[1] == 't' && s[2] == 'r' && s[3] == 'u' && s[4] == 'c' && s[5] == 't' && s[6] == ' ')
     {
         tstart += 7;
     }
@@ -83,17 +95,19 @@ C4_CONSTEXPR14 cspan<char> type_name()
 #elif defined(__ICC)
     // example:
     // ........................xxx.
-    // "_c4t _c4tn() [with T = int]"
+    // "c4t_ c4tn_() [with T = int]"
     enum : size_t { tstart = 23, tend = 1};
 
 #elif defined(__clang__)
     // example:
     // ...................xxx.
-    // "_c4t _c4tn() [T = int]"
+    // "c4t_ c4tn_() [T = int]"
     enum : size_t { tstart = 18, tend = 1};
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wuninitialized"
 
 #elif defined(__GNUC__)
-    #if __GNUC__ >= 7 && C4_CPP >= 14
+    #if (__GNUC__ >= 5) || (C4_CPP >= 14)
         // example:
         // ..................................xxx.
         // "constexpr _c4t _c4tn() [with T = int]"
@@ -104,11 +118,20 @@ C4_CONSTEXPR14 cspan<char> type_name()
         // "_c4t _c4tn() [with T = int]"
         enum : size_t { tstart = 23, tend = 1 };
     #endif
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wuninitialized"
 #else
-    C4_NOT_IMPLEMENTED();
+    #error not implemented
 #endif
 
-    cspan<char> o(p.str + tstart, p.sz - tstart - tend);
+    TypeNameStr o{p.str + tstart, p.sz - tstart - tend};
+
+#if defined(_MSC_VER)
+#elif defined(__clang__)
+    #pragma clang diagnostic pop
+#elif defined(__GNUC__)
+    #pragma GCC diagnostic pop
+#endif
 
     return o;
 }
@@ -116,7 +139,7 @@ C4_CONSTEXPR14 cspan<char> type_name()
 /** compile-time type name
  * @overload */
 template<class T>
-C4_CONSTEXPR14 C4_ALWAYS_INLINE cspan<char> type_name(T const&)
+C4_CONSTEXPR14 C4_ALWAYS_INLINE TypeNameStr type_name(T const&) noexcept
 {
     return type_name<T>();
 }

--- a/src/c4/types.hpp
+++ b/src/c4/types.hpp
@@ -40,7 +40,7 @@ using u64 = uint64_t;
 using f32 =  float;
 using f64 = double;
 
-using ssize_t = typename std::make_signed<size_t>::type;
+using ssize_t = typename std::make_signed<size_t>::type; // NOLINT
 
 /** @} */
 

--- a/src/c4/utf.cpp
+++ b/src/c4/utf.cpp
@@ -23,17 +23,17 @@ size_t decode_code_point(uint8_t *C4_RESTRICT buf, size_t buflen, const uint32_t
     }
     else if(code <= UINT32_C(0xffff))
     {
-        buf[0] = (uint8_t)(UINT32_C(0xe0) | ((code >> 12u)));                  /* 1110xxxx */
+        buf[0] = (uint8_t)(UINT32_C(0xe0) | ((code >> 12u)));                  /* 1110xxxx */ // NOLINT
         buf[1] = (uint8_t)(UINT32_C(0x80) | ((code >>  6u) & UINT32_C(0x3f))); /* 10xxxxxx */
-        buf[2] = (uint8_t)(UINT32_C(0x80) | ((code       ) & UINT32_C(0x3f))); /* 10xxxxxx */
+        buf[2] = (uint8_t)(UINT32_C(0x80) | ((code       ) & UINT32_C(0x3f))); /* 10xxxxxx */ // NOLINT
         return 3u;
     }
     else if(code <= UINT32_C(0x10ffff))
     {
-        buf[0] = (uint8_t)(UINT32_C(0xf0) | ((code >> 18u)));                  /* 11110xxx */
+        buf[0] = (uint8_t)(UINT32_C(0xf0) | ((code >> 18u)));                  /* 11110xxx */ // NOLINT
         buf[1] = (uint8_t)(UINT32_C(0x80) | ((code >> 12u) & UINT32_C(0x3f))); /* 10xxxxxx */
         buf[2] = (uint8_t)(UINT32_C(0x80) | ((code >>  6u) & UINT32_C(0x3f))); /* 10xxxxxx */
-        buf[3] = (uint8_t)(UINT32_C(0x80) | ((code       ) & UINT32_C(0x3f))); /* 10xxxxxx */
+        buf[3] = (uint8_t)(UINT32_C(0x80) | ((code       ) & UINT32_C(0x3f))); /* 10xxxxxx */ // NOLINT
         return 4u;
     }
     return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,3 +58,26 @@ c4core_test(format           test_format.cpp)
 c4core_test(dump             test_dump.cpp)
 c4core_test(base64           test_base64.cpp)
 c4core_test(std              test_std.cpp)
+
+
+#----------------------------------------------------------
+
+function(c4core_test_failbuild subject name code)
+    set(target c4core-test-${subject}-failbuild-${name})
+    set(test ${target})
+    set(filename "${CMAKE_CURRENT_BINARY_DIR}/${name}.cpp")
+    file(WRITE "${filename}" "${code}")
+    c4_add_executable(${target}
+        SOURCES ${filename}
+        LIBS c4core
+        FOLDER test)
+    set_target_properties(${target} PROPERTIES
+        EXCLUDE_FROM_ALL TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+    add_test(NAME ${test}
+        COMMAND ${CMAKE_COMMAND} --build . --target ${target} --config $<CONFIGURATION>
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    set_tests_properties(${test} PROPERTIES WILL_FAIL TRUE)
+endfunction()
+
+include(test_substr.cmake)

--- a/test/test_substr.cmake
+++ b/test/test_substr.cmake
@@ -1,0 +1,42 @@
+
+set(substr_counter_failbuild 0)
+function(c4core_add_failbuild_substr code)
+    c4core_test_failbuild(substr ${substr_counter_failbuild} "#include <c4/substr.hpp>
+#include <c4/std/std.hpp>
+using namespace c4;
+int main()
+{
+    ${code}
+}
+")
+    math(EXPR substr_counter_failbuild "${substr_counter_failbuild}+1")
+    set(substr_counter_failbuild ${substr_counter_failbuild} PARENT_SCOPE)
+endfunction()
+
+c4core_add_failbuild_substr("substr dst = \"const literal\";")
+c4core_add_failbuild_substr("csubstr src; substr dst = src;")
+c4core_add_failbuild_substr("const char buf[20]; substr bad(buf);")
+c4core_add_failbuild_substr("const char buf[20]; substr bad = buf;")
+c4core_add_failbuild_substr("char buf[20]; csubstr(buf).toupper(); ")
+c4core_add_failbuild_substr("char buf[20]; csubstr(buf).tolower(); ")
+c4core_add_failbuild_substr("char buf[20]; csubstr(buf).fill(0); ")
+c4core_add_failbuild_substr("char buf[20]; csubstr(buf).copy_from(\"asdasd\"); ")
+c4core_add_failbuild_substr("char buf[20]; csubstr(buf).reverse(); ")
+c4core_add_failbuild_substr("char buf[20]; csubstr(buf).reverse_sub(0, 10); ")
+
+c4core_add_failbuild_substr("const char* s = \"a\"; to_substr(s); ")
+c4core_add_failbuild_substr("const char* s = \"a\"; substr ss; ss.assign(s); ")
+c4core_add_failbuild_substr("const char* s = \"a\"; substr ss; ss = s; ")
+
+c4core_add_failbuild_substr("const std::string s; to_substr(s); ")
+c4core_add_failbuild_substr("const std::vector<char> s; to_substr(s); ")
+
+c4core_add_failbuild_substr("int* s = nullptr; substr ss(s); ")
+c4core_add_failbuild_substr("int* s = nullptr; substr ss; ss = s; ")
+c4core_add_failbuild_substr("int* s = nullptr; substr ss; ss.assign(s); ")
+c4core_add_failbuild_substr("int* s = nullptr; to_substr(s); ")
+
+c4core_add_failbuild_substr("const int* s = nullptr; csubstr ss(s); ")
+c4core_add_failbuild_substr("const int* s = nullptr; csubstr ss; ss = s; ")
+c4core_add_failbuild_substr("const int* s = nullptr; csubstr ss; ss.assign(s); ")
+c4core_add_failbuild_substr("const int* s = nullptr; to_csubstr(s); ")

--- a/test/test_substr.cpp
+++ b/test/test_substr.cpp
@@ -8,195 +8,497 @@
 #include "c4/libtest/supprwarn_push.hpp"
 #include <iostream>
 
+#if (defined(__clang__) && defined(__clang_major__) && __clang_major__ <= 7)
+#define CLANG_WORKAROUND_RESTRICT
+#endif
+
 namespace c4 {
 
-static_assert(c4::is_string<char[2]>::value, "dump directly");
-static_assert(c4::is_string<char(&)[2]>::value, "dump directly");
-static_assert(c4::is_string<char(&&)[2]>::value, "dump directly");
-static_assert(c4::is_string<const char[2]>::value, "dump directly");
-static_assert(c4::is_string<const char(&&)[2]>::value, "dump directly");
-static_assert(c4::is_string<substr>::value, "dump directly");
-static_assert(c4::is_string<csubstr>::value, "dump directly");
-static_assert(c4::is_string<std::string>::value, "dump directly");
+// we're using functions to force the compiler to print the actual
+// types. this is useful later on; see below
+template<class Actual, class Expected>
+constexpr bool test_same()
+{
+    static_assert(std::is_same<Actual, Expected>::value, "is_same");
+    return true;
+}
+
+static_assert(test_same<detail::remove_restrict<char*>::type, char*>(), "remove restrict");
+static_assert(test_same<detail::remove_restrict<char&>::type, char&>(), "remove restrict");
+static_assert(test_same<detail::remove_restrict<char* C4_RESTRICT>::type, char*>(), "remove restrict");
+#ifndef CLANG_WORKAROUND_RESTRICT
+static_assert(test_same<detail::remove_restrict<char& C4_RESTRICT>::type, char&>(), "remove restrict");
+#endif
 
 
-TEST_CASE("substr.empty_ctor")
+//-----------------------------------------------------------------------------
+
+template<class T, class Expected>
+constexpr bool test_remove_ptrref()
+{
+    using Actual = typename detail::remove_ptrref<T>::type;
+    static_assert(std::is_same<Actual, Expected>::value, "ptrref");
+    return true;
+}
+
+static_assert(test_remove_ptrref<char*&, char*>(), "ptrref");
+static_assert(test_remove_ptrref<char* const&, char *const>(), "ptrref");
+static_assert(test_remove_ptrref<char&, char&>(), "ptrref");
+static_assert(test_remove_ptrref<char*, char*>(), "ptrref");
+static_assert(test_remove_ptrref<char& C4_RESTRICT, char& C4_RESTRICT>(), "ptrref");
+static_assert(test_remove_ptrref<char* C4_RESTRICT, char* C4_RESTRICT>(), "ptrref");
+static_assert(test_remove_ptrref<char* C4_RESTRICT &, char* C4_RESTRICT>(), "ptrref");
+static_assert(test_remove_ptrref<char* C4_RESTRICT, char* C4_RESTRICT>(), "ptrref");
+static_assert(test_remove_ptrref<char* C4_RESTRICT &, char* C4_RESTRICT>(), "ptrref");
+
+
+//-----------------------------------------------------------------------------
+
+template<class T, class Expected>
+constexpr bool test_bare_pointer_type()
+{
+    using Actual = typename detail::bare_pointer_type<T>::type;
+    static_assert(std::is_same<Actual, Expected>::value, "bare type");
+    return true;
+}
+
+static_assert(test_bare_pointer_type<char*, char*>(), "bare type");
+static_assert(test_bare_pointer_type<char* C4_RESTRICT, char*>(), "bare type");
+static_assert(test_bare_pointer_type<char* C4_RESTRICT&, char*>(), "bare type");
+#ifndef CLANG_WORKAROUND_RESTRICT
+static_assert(test_bare_pointer_type<char& C4_RESTRICT, char&>(), "bare type");
+#endif
+
+static_assert(test_bare_pointer_type<char* const, char*>(), "bare type");
+static_assert(test_bare_pointer_type<char* const&, char*>(), "bare type");
+static_assert(test_bare_pointer_type<char* const C4_RESTRICT, char*>(), "bare type");
+
+static_assert(test_bare_pointer_type<const char*, const char*>(), "bare type");
+static_assert(test_bare_pointer_type<char const*, char const*>(), "bare type");
+static_assert(test_bare_pointer_type<char const* C4_RESTRICT, char const*>(), "bare type");
+#ifndef CLANG_WORKAROUND_RESTRICT
+static_assert(test_bare_pointer_type<char const& C4_RESTRICT, char const&>(), "bare type");
+#endif
+
+static_assert(test_bare_pointer_type<char const* const, char const*>(), "bare type");
+static_assert(test_bare_pointer_type<char const* C4_RESTRICT const, char const*>(), "bare type");
+
+static_assert(test_bare_pointer_type<char[2], char[2]>(), "bare type");
+static_assert(test_bare_pointer_type<const char[2], const char[2]>(), "bare type");
+
+
+//-----------------------------------------------------------------------------
+
+
+template<class Bare, class C1, class C2>
+constexpr bool test_one_of_() noexcept
+{
+    static_assert(std::is_same<Bare, C1>::value || std::is_same<Bare, C2>::value, "one of bare");
+    return true;
+}
+template<class Bare, class C1, class C2>
+constexpr bool test_not_one_of_() noexcept
+{
+    static_assert(!std::is_same<Bare, C1>::value && !std::is_same<Bare, C2>::value, "not one of bare");
+    return true;
+}
+
+template<class T, class C1, class C2>
+constexpr bool test_one_of() noexcept
+{
+    using Bare = typename detail::bare_pointer_type<T>::type;
+    static_assert(test_one_of_<Bare, C1, C2>(), "one of");
+    return true;
+}
+template<class T, class C1, class C2>
+constexpr bool test_not_one_of() noexcept
+{
+    using Bare = typename detail::bare_pointer_type<T>::type;
+    static_assert(test_not_one_of_<Bare, C1, C2>(), "not one of");
+    return true;
+}
+
+static_assert(test_one_of<char      *      , char*, char const*>(), "can_read");
+static_assert(test_one_of<char const*      , char*, char const*>(), "can_read");
+static_assert(test_one_of<char      * const, char*, char const*>(), "can_read");
+static_assert(test_one_of<char const* const, char*, char const*>(), "can_read");
+
+static_assert(test_not_one_of< substr, char*, char const*>(), "can_read");
+static_assert(test_not_one_of<csubstr, char*, char const*>(), "can_read");
+
+
+//-----------------------------------------------------------------------------
+
+template<class From, class To>
+constexpr bool test_can_read() noexcept
+{
+    static_assert(is_compatible_char_ptr<From, To>::value, "can read");
+    return true;
+}
+template<class From, class To>
+constexpr bool test_cannot_read() noexcept
+{
+    static_assert(!is_compatible_char_ptr<From, To>::value, "can read");
+    return true;
+}
+template<class From, class To>
+constexpr bool test_can_borrow() noexcept
+{
+    static_assert(can_borrow_char_ptr<From, To>::value, "can borrow");
+    return true;
+}
+template<class From, class To>
+constexpr bool test_cannot_borrow() noexcept
+{
+    static_assert(!can_borrow_char_ptr<From, To>::value, "can borrow");
+    return true;
+}
+
+static_assert(test_can_read<      char*,       char>(), "can_read");
+static_assert(test_can_read<const char*,       char>(), "can_read");
+static_assert(test_can_read<      char*, const char>(), "can_read");
+static_assert(test_can_read<const char*, const char>(), "can_read");
+
+static_assert(test_can_borrow   <      char*,       char>(), "can_borrow");
+static_assert(test_cannot_borrow<const char*,       char>(), "can_borrow");
+static_assert(test_can_borrow   <      char*, const char>(), "can_borrow");
+static_assert(test_can_borrow   <const char*, const char>(), "can_borrow");
+
+
+static_assert(test_cannot_read< substr,       char>(), "can_read");
+static_assert(test_cannot_read<csubstr,       char>(), "can_read");
+static_assert(test_cannot_read< substr, const char>(), "can_read");
+static_assert(test_cannot_read<csubstr, const char>(), "can_read");
+
+static_assert(test_cannot_borrow< substr,       char>(), "can_borrow");
+static_assert(test_cannot_borrow<csubstr,       char>(), "can_borrow");
+static_assert(test_cannot_borrow< substr, const char>(), "can_borrow");
+static_assert(test_cannot_borrow<csubstr, const char>(), "can_borrow");
+
+
+//-----------------------------------------------------------------------------
+
+#define STRTYPES_PTR_RW(macro)                    \
+    macro(char*)                                  \
+    macro(char* const)                            \
+    macro(char* C4_RESTRICT)                      \
+    macro(char* C4_RESTRICT const)
+
+#define STRTYPES_PTR_RO(macro)                      \
+    macro(const char*)                              \
+    macro(const char* const)                        \
+    macro(const char* C4_RESTRICT)                  \
+    macro(const char* C4_RESTRICT const)
+
+#ifndef CLANG_WORKAROUND_RESTRICT
+#define STRTYPES_ARR_RW(macro, N)               \
+    macro(char[N])                              \
+    macro(char(&)[N])                           \
+    macro(char(& C4_RESTRICT)[N])
+#define STRTYPES_ARR_RO(macro, N)                   \
+    macro(const char[N])                            \
+    macro(const char(&)[N])                         \
+    macro(const char(& C4_RESTRICT)[N])
+#else
+#define STRTYPES_ARR_RW(macro, N)               \
+    macro(char[N])                              \
+    macro(char(&)[N])
+#define STRTYPES_ARR_RO(macro, N)               \
+    macro(const char[N])                        \
+    macro(const char(&)[N])
+#endif
+
+#if C4_CPP >= 20
+#define STRTYPES_CLASSES_STD_RW(macro)          \
+    macro(std::span<char>)                      \
+    macro(const std::span<char>)                \
+    macro(std::string)
+#define STRTYPES_CLASSES_STD_RO(macro)          \
+    macro(std::span<const char>)                \
+    macro(const std::span<const char>)          \
+    macro(const std::string)                    \
+    macro(std::string_view)
+#elif C4_CPP >= 17
+#define STRTYPES_CLASSES_STD_RW(macro)          \
+    macro(std::string)
+#define STRTYPES_CLASSES_STD_RO(macro)          \
+    macro(const std::string)                    \
+    macro(std::string_view)                     \
+    macro(const std::string_view)
+#else
+#define STRTYPES_CLASSES_STD_RW(macro) \
+    macro(std::string)                 \
+    macro(std::vector<char>)
+#define STRTYPES_CLASSES_STD_RO(macro) \
+    macro(const std::string)           \
+    macro(const std::vector<char>)
+#endif
+
+#define STRTYPES_RW(macro)                      \
+    STRTYPES_PTR_RW(macro)                      \
+    STRTYPES_CLASSES_STD_RW(macro)              \
+    macro(substr)                               \
+    macro(const substr)
+
+#define STRTYPES_RO(macro)                      \
+    STRTYPES_PTR_RO(macro)                      \
+    STRTYPES_CLASSES_STD_RO(macro)              \
+    macro(csubstr)                              \
+    macro(const csubstr)
+
+
+template<class T>
+constexpr bool test_is_writeable_string()
+{
+    static_assert(c4::is_string<T>::value, "is_string");
+    static_assert(c4::is_writeable_string<T>::value, "is_writeable_string");
+    return true;
+}
+template<class T>
+constexpr bool test_is_readonly_string()
+{
+    static_assert(c4::is_string<T>::value, "is_string");
+    static_assert( ! c4::is_writeable_string<T>::value, "is_writeable_string");
+    return true;
+}
+#define test_is_writeable_string_(T) static_assert(test_is_writeable_string<T>(), "is_writeable_string");
+#define test_is_readonly_string_(T) static_assert(test_is_readonly_string<T>(), "is_readonly_string");
+
+STRTYPES_RW(test_is_writeable_string_)
+STRTYPES_RO(test_is_readonly_string_)
+STRTYPES_ARR_RW(test_is_writeable_string_, 2)
+STRTYPES_ARR_RO(test_is_readonly_string_, 2)
+
+
+//-----------------------------------------------------------------------------
+
+void test_substr_convert_to_substr(csubstr cs, substr s)
+{
+    CHECK_EQ(cs.len, s.len);
+    CHECK_EQ(cs.str, s.str);
+}
+
+void test_substr_convert_to_substr(substr s)
+{
+    CAPTURE(s);
+    {
+        INFO("ctor");
+        csubstr cs(s);
+        test_substr_convert_to_substr(cs, s);
+    }
+    {
+        INFO("copy ctor");
+        csubstr cs = s;
+        test_substr_convert_to_substr(cs, s);
+    }
+    {
+        INFO("copy assign");
+        csubstr cs;
+        cs = s;
+        test_substr_convert_to_substr(cs, s);
+    }
+    {
+        INFO("implicit");
+        test_substr_convert_to_substr(s, s);
+    }
+}
+
+TEST_CASE("substr.auto_conversion_to_csubstr")
+{
+    test_substr_convert_to_substr(nullptr);
+    char buf[] = "0123456789";
+    substr s = buf;
+    for(size_t i = 0; i < s.len; ++i)
+        test_substr_convert_to_substr(s.first(i));
+}
+
+
+TEST_CASE_TEMPLATE("to_substr.string", T, std::string)
 {
     {
-        substr s;
+        T empty;
+        CHECK_EQ(to_substr(empty), "");
+        CHECK_EQ(to_substr(empty).str, empty.data());
+        CHECK_EQ(to_substr(empty).len, empty.size());
+        CHECK_EQ(to_csubstr(empty), "");
+        CHECK_EQ(to_csubstr(empty).str, empty.data());
+        CHECK_EQ(to_csubstr(empty).len, empty.size());
+    }
+    {
+        T foo("foo");
+        CHECK_EQ(to_substr(foo), "foo");
+        CHECK_EQ(to_substr(foo).str, foo.data());
+        CHECK_EQ(to_substr(foo).len, foo.size());
+        CHECK_EQ(to_csubstr(foo), "foo");
+        CHECK_EQ(to_csubstr(foo).str, foo.data());
+        CHECK_EQ(to_csubstr(foo).len, foo.size());
+    }
+}
+
+#if C4_CPP >= 17
+TEST_CASE_TEMPLATE("to_substr.const_string_view", T, const std::string, std::string_view)
+#else
+TEST_CASE_TEMPLATE("to_substr.const_string_view", T, const std::string)
+#endif
+{
+    {
+        T empty;
+        CHECK_EQ(to_csubstr(empty), "");
+        CHECK_EQ(to_csubstr(empty).str, empty.data());
+        CHECK_EQ(to_csubstr(empty).len, empty.size());
+    }
+    {
+        T foo("foo");
+        CHECK_EQ(to_csubstr(foo), "foo");
+        CHECK_EQ(to_csubstr(foo).str, foo.data());
+        CHECK_EQ(to_csubstr(foo).len, foo.size());
+    }
+}
+
+#if C4_CPP >= 20
+TEST_CASE_TEMPLATE("to_substr.vecspan", T, std::vector<char>, std::span<char>)
+#else
+TEST_CASE_TEMPLATE("to_substr.vecspan", T, std::vector<char>)
+#endif
+{
+    {
+        T empty;
+        CHECK_EQ(to_substr(empty), "");
+        CHECK_EQ(to_substr(empty).str, empty.data());
+        CHECK_EQ(to_substr(empty).len, empty.size());
+        CHECK_EQ(to_csubstr(empty), "");
+        CHECK_EQ(to_csubstr(empty).str, empty.data());
+        CHECK_EQ(to_csubstr(empty).len, empty.size());
+    }
+    {
+        typename T::value_type values[] =  {'f', 'o', 'o'};
+        T foo(std::begin(values), std::end(values));
+        CHECK_EQ(to_substr(foo), "foo");
+        CHECK_EQ(to_substr(foo).str, foo.data());
+        CHECK_EQ(to_substr(foo).len, foo.size());
+        CHECK_EQ(to_csubstr(foo), "foo");
+        CHECK_EQ(to_csubstr(foo).str, foo.data());
+        CHECK_EQ(to_csubstr(foo).len, foo.size());
+    }
+}
+
+#if C4_CPP >= 20
+TEST_CASE_TEMPLATE("to_substr.vecspan", T, const std::vector<char>, std::span<const char>)
+#else
+TEST_CASE_TEMPLATE("to_substr.vecspan", T, const std::vector<char>)
+#endif
+{
+    {
+        T empty;
+        CHECK_EQ(to_csubstr(empty), "");
+        CHECK_EQ(to_csubstr(empty).str, empty.data());
+        CHECK_EQ(to_csubstr(empty).len, empty.size());
+    }
+    {
+        typename T::value_type values[] =  {'f', 'o', 'o'};
+        T foo(std::begin(values), std::end(values));
+        CHECK_EQ(to_csubstr(foo), "foo");
+        CHECK_EQ(to_csubstr(foo).str, foo.data());
+        CHECK_EQ(to_csubstr(foo).len, foo.size());
+    }
+}
+
+
+//-----------------------------------------------------------------------------
+
+TEST_CASE_TEMPLATE("substr.empty_ctor", T, substr, csubstr)
+{
+    {
+        T s;
         CHECK_EQ(s.str, nullptr);
         CHECK_EQ(s.len, 0u);
     }
     {
-        csubstr s;
-        CHECK_EQ(s.str, nullptr);
-        CHECK_EQ(s.len, 0u);
-    }
-    {
-        substr s = {};
-        CHECK_EQ(s.str, nullptr);
-        CHECK_EQ(s.len, 0u);
-    }
-    {
-        csubstr s = {};
+        T s = {};
         CHECK_EQ(s.str, nullptr);
         CHECK_EQ(s.len, 0u);
     }
 }
 
-TEST_CASE("substr.ctor_from_char_arr")
+
+template<class PtrType>
+void test_substr_from_ptr(PtrType ptr1, PtrType ptr2, csubstr expected1, csubstr expected2)
 {
-    SUBCASE("substr from char")
-    {
-        char buf1[] = "01";
-        char buf2[] = "012";
-        substr s(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = buf2;
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s.assign(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = to_substr(buf2);
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        //s = to_csubstr(buf1); // deliberate compile error
-        //CHECK_EQ(s, "01");
-        //CHECK_EQ(s.str, buf1);
-        //CHECK_EQ(s.len, strlen(buf1));
-    }
-    SUBCASE("csubstr from char")
-    {
-        char buf1[] = "01";
-        char buf2[] = "012";
-        csubstr s(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = buf2;
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s.assign(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = to_substr(buf2);
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s = to_csubstr(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-    }
-    SUBCASE("csubstr from const char")
-    {
-        const char buf1[] = "01";
-        const char buf2[] = "012";
-        csubstr s(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = buf2;
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s.assign(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        // s = to_substr(buf2); // deliberate compile error
-        s = to_csubstr(buf2);
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-    }
+    substr s(ptr1);
+    CHECK_EQ(s, expected1);
+    CHECK_EQ(s.str, ptr1);
+    CHECK_EQ(s.len, expected1.len);
+    s = ptr2;
+    CHECK_EQ(s, expected2);
+    CHECK_EQ(s.str, ptr2);
+    CHECK_EQ(s.len, expected2.len);
+    s.assign(ptr1);
+    CHECK_EQ(s, expected1);
+    CHECK_EQ(s.str, ptr1);
+    CHECK_EQ(s.len, expected1.len);
+    s = to_substr(ptr2);
+    CHECK_EQ(s, expected2);
+    CHECK_EQ(s.str, ptr2);
+    CHECK_EQ(s.len, expected2.len);
+}
+template<class PtrType>
+void test_csubstr_from_ptr(PtrType ptr1, PtrType ptr2, csubstr expected1, csubstr expected2)
+{
+    csubstr s(ptr1);
+    CHECK_EQ(s, expected1);
+    CHECK_EQ(s.str, ptr1);
+    CHECK_EQ(s.len, expected1.len);
+    s = ptr2;
+    CHECK_EQ(s, expected2);
+    CHECK_EQ(s.str, ptr2);
+    CHECK_EQ(s.len, expected2.len);
+    s.assign(ptr1);
+    CHECK_EQ(s, expected1);
+    CHECK_EQ(s.str, ptr1);
+    CHECK_EQ(s.len, expected1.len);
+    s = to_csubstr(ptr2);
+    CHECK_EQ(s, expected2);
+    CHECK_EQ(s.str, ptr2);
+    CHECK_EQ(s.len, expected2.len);
 }
 
-TEST_CASE("substr.ctor_from_char_ptr")
+template<class PtrType>
+void test_substr_from_ptr()
 {
-    {
-        char buf1_[] = "01";
-        char buf2_[] = "012";
-        char *buf1 = buf1_;
-        char *buf2 = buf2_;
-        substr s(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = buf2;
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s.assign(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = to_substr(buf2);
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        //s = to_csubstr(buf1);  // deliberate compile error
-        //CHECK_EQ(s, "01");
-        //CHECK_EQ(s.str, buf1);
-        //CHECK_EQ(s.len, strlen(buf1));
-    }
-    {
-        char buf1_[] = "01";
-        char buf2_[] = "012";
-        char *buf1 = buf1_;
-        char *buf2 = buf2_;
-        csubstr s(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = buf2;
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s.assign(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = to_substr(buf2);
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s = to_csubstr(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-    }
-    {
-        const char buf1_[] = "01";
-        const char buf2_[] = "012";
-        const char *buf1 = buf1_;
-        const char *buf2 = buf2_;
-        csubstr s(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        s = buf2;
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-        s.assign(buf1);
-        CHECK_EQ(s, "01");
-        CHECK_EQ(s.str, buf1);
-        CHECK_EQ(s.len, strlen(buf1));
-        //s = to_substr(buf2);  // deliberate compile error
-        s = to_csubstr(buf2);
-        CHECK_EQ(s, "012");
-        CHECK_EQ(s.str, buf2);
-        CHECK_EQ(s.len, strlen(buf2));
-    }
+    char buf1[] = "012";
+    char buf2[] = "345";
+    test_substr_from_ptr<PtrType>(buf1, buf2, "012", "345");
+}
+
+template<class PtrType>
+void test_csubstr_from_ptr()
+{
+    char buf1[] = "012";
+    char buf2[] = "345";
+    test_csubstr_from_ptr<PtrType>(buf1, buf2, "012", "345");
+}
+
+#define trivial(...) __VA_ARGS__,
+
+TEST_CASE_TEMPLATE("substr.from_char_ptr",
+                   PtrType,
+                   STRTYPES_PTR_RW(trivial)
+                   STRTYPES_ARR_RW(trivial, 4)
+                   char*)
+{
+    test_substr_from_ptr<PtrType>();
+    test_csubstr_from_ptr<PtrType>();
+}
+
+TEST_CASE_TEMPLATE("csubstr.from_char_ptr",
+                   PtrType,
+                   STRTYPES_PTR_RW(trivial)
+                   STRTYPES_ARR_RW(trivial, 4)
+                   STRTYPES_PTR_RO(trivial)
+                   STRTYPES_ARR_RO(trivial, 4)
+                   char*)
+{
+    test_csubstr_from_ptr<PtrType>();
 }
 
 TEST_CASE("substr.ctor_from_two_ptrs")
@@ -1461,6 +1763,116 @@ TEST_CASE_TEMPLATE("substr.eqne", SS, csubstr, substr)
     CHECK_NE("012345", cmp);
     CHECK_NE(cmp, "012345");
 }
+
+template<class Substr, class Type>
+void test_cmp(Substr subject,
+              Type eq, Type ne,
+              Type lt, Type gt)
+{
+    CHECK_EQ(subject, eq);
+    CHECK_EQ(eq, subject);
+
+    CHECK_NE(subject, ne);
+    CHECK_NE(ne, subject);
+
+    CHECK_LE(eq, subject);
+    CHECK_LT(lt, subject);
+    CHECK_GE(subject, lt);
+    CHECK_GE(subject, eq);
+
+    CHECK_GE(eq, subject);
+    CHECK_GT(gt, subject);
+    CHECK_LE(subject, gt);
+    CHECK_LE(subject, eq);
+}
+
+TEST_CASE_TEMPLATE("substr.cmp_char", T, char, const char)
+{
+    char buf[] = "d";
+    test_cmp<substr, T>(buf,
+                        /*eq*/'d', /*ne*/'a',
+                        /*lt*/'a', /*gt*/'e');
+}
+TEST_CASE_TEMPLATE("csubstr.cmp_char", T, char, const char)
+{
+    const char buf[] = "d";
+    test_cmp<csubstr, T>(buf,
+                        /*eq*/'d', /*ne*/'a',
+                        /*lt*/'a', /*gt*/'e');
+}
+
+TEST_CASE_TEMPLATE("substr.cmp",
+                   T,
+                   STRTYPES_PTR_RW(trivial)
+                   STRTYPES_ARR_RW(trivial, 4)
+                   std::string)
+{
+    char buf[] = "bcd";
+    char eq[] = "bcd";
+    char ne[] = "xxx";
+    char lt[] = "abc";
+    char gt[] = "cde";
+    test_cmp<substr, T>(buf, eq, ne, lt, gt);
+}
+
+#if C4_CPP >= 17
+#define string_view_types  std::string_view, const std::string_view,
+#else
+#define string_view_types
+#endif
+
+TEST_CASE_TEMPLATE("csubstr.cmp",
+                   T,
+                   STRTYPES_PTR_RW(trivial)
+                   STRTYPES_ARR_RW(trivial, 4)
+                   STRTYPES_PTR_RO(trivial)
+                   STRTYPES_ARR_RO(trivial, 4)
+                   std::string,
+                   const std::string,
+                   string_view_types
+                   char*
+                   )
+{
+    char buf[] = "bcd";
+    char eq[] = "bcd";
+    char ne[] = "xxx";
+    char lt[] = "abc";
+    char gt[] = "cde";
+    test_cmp<csubstr, T>(buf, eq, ne, lt, gt);
+}
+
+#if C4_CPP >= 20
+TEST_CASE_TEMPLATE("substr.cmp_span",
+                   T,
+                   std::span<char>,
+                   const std::span<char>
+    )
+{
+    char buf[] = "bcd";
+    char eq[3] = {'b','c','d'};
+    char ne[3] = {'x','x','x'};
+    char lt[3] = {'a','b','c'};
+    char gt[3] = {'c','d','e'};
+    test_cmp<substr, T>(buf, eq, ne, lt, gt);
+}
+TEST_CASE_TEMPLATE("csubstr.cmp_span",
+                   T,
+                   std::span<char>,
+                   const std::span<char>,
+                   std::span<const char>,
+                   const std::span<const char>
+                   )
+{
+    char buf[] = "bcd";
+    char eq[3] = {'b','c','d'};
+    char ne[3] = {'x','x','x'};
+    char lt[3] = {'a','b','c'};
+    char gt[3] = {'c','d','e'};
+    test_cmp<csubstr, T>(buf, eq, ne, lt, gt);
+}
+#endif
+
+//-----------------------------------------------------------------------------
 
 TEST_CASE("substr.substr2csubstr")
 {

--- a/test/test_substr.cpp
+++ b/test/test_substr.cpp
@@ -1,4 +1,5 @@
 #ifndef C4CORE_SINGLE_HEADER
+#include "c4/std/std_fwd.hpp" // include this to test compatibility of fwd and actual headers
 #include "c4/std/std.hpp"
 #include "c4/substr.hpp"
 #endif

--- a/test/test_type_name.cpp
+++ b/test/test_type_name.cpp
@@ -2,6 +2,7 @@
 
 #ifndef C4CORE_SINGLE_HEADER
 #include "c4/type_name.hpp"
+#include "c4/substr.hpp"
 #endif
 
 class  SomeTypeName {};
@@ -12,38 +13,47 @@ namespace c4 {
 class  SomeTypeNameInsideANamespace {};
 struct SomeStructNameInsideANamespace {};
 
-template<size_t N>
-cspan<char> cstr(const char (&s)[N])
+template<class T>
+void test_type_name(csubstr expected)
 {
-    cspan<char> o(s, N-1);
-    return o;
+    {
+        TypeNameStr result = type_name<T>();
+        csubstr actual{result.str, result.len};
+        CHECK_EQ(actual, expected);
+    }
+    {
+        T val{};
+        TypeNameStr result = type_name(val);
+        csubstr actual{result.str, result.len};
+        CHECK_EQ(actual, expected);
+    }
 }
 
 TEST_CASE("type_name.intrinsic_types")
 {
-    CHECK_EQ(type_name<int>(), cstr("int"));
-    CHECK_EQ(type_name<float>(), cstr("float"));
-    CHECK_EQ(type_name<double>(), cstr("double"));
+    test_type_name<int>("int");
+    test_type_name<float>("float");
+    test_type_name<double>("double");
 }
 TEST_CASE("type_name.classes")
 {
-    CHECK_EQ(type_name<SomeTypeName>(), cstr("SomeTypeName"));
-    CHECK_EQ(type_name<::SomeTypeName>(), cstr("SomeTypeName"));
+    test_type_name<SomeTypeName>("SomeTypeName");
+    test_type_name<::SomeTypeName>("SomeTypeName");
 }
 TEST_CASE("type_name.structs")
 {
-    CHECK_EQ(type_name<SomeStructName>(), cstr("SomeStructName"));
-    CHECK_EQ(type_name<::SomeStructName>(), cstr("SomeStructName"));
+    test_type_name<SomeStructName>("SomeStructName");
+    test_type_name<::SomeStructName>("SomeStructName");
 }
 TEST_CASE("type_name.inside_namespace")
 {
-    CHECK_EQ(type_name<SomeTypeNameInsideANamespace>(), cstr("c4::SomeTypeNameInsideANamespace"));
-    CHECK_EQ(type_name<c4::SomeTypeNameInsideANamespace>(), cstr("c4::SomeTypeNameInsideANamespace"));
-    CHECK_EQ(type_name<::c4::SomeTypeNameInsideANamespace>(), cstr("c4::SomeTypeNameInsideANamespace"));
+    test_type_name<SomeTypeNameInsideANamespace>("c4::SomeTypeNameInsideANamespace");
+    test_type_name<c4::SomeTypeNameInsideANamespace>("c4::SomeTypeNameInsideANamespace");
+    test_type_name<::c4::SomeTypeNameInsideANamespace>("c4::SomeTypeNameInsideANamespace");
 
-    CHECK_EQ(type_name<SomeStructNameInsideANamespace>(), cstr("c4::SomeStructNameInsideANamespace"));
-    CHECK_EQ(type_name<c4::SomeStructNameInsideANamespace>(), cstr("c4::SomeStructNameInsideANamespace"));
-    CHECK_EQ(type_name<::c4::SomeStructNameInsideANamespace>(), cstr("c4::SomeStructNameInsideANamespace"));
+    test_type_name<SomeStructNameInsideANamespace>("c4::SomeStructNameInsideANamespace");
+    test_type_name<c4::SomeStructNameInsideANamespace>("c4::SomeStructNameInsideANamespace");
+    test_type_name<::c4::SomeStructNameInsideANamespace>("c4::SomeStructNameInsideANamespace");
 }
 
 } // namespace c4

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -92,6 +92,7 @@ INSTRUCTIONS:
         am.onlyif(with_stl, "src/c4/std/vector_fwd.hpp"),
         am.onlyif(with_stl, "src/c4/std/span_fwd.hpp"),
         am.onlyif(with_stl, "src/c4/std/string_fwd.hpp"),
+        am.onlyif(with_stl, "src/c4/std/string_view_fwd.hpp"),
         am.onlyif(with_stl, "src/c4/std/std_fwd.hpp"),
         am.injcode(required_charconv_include),
         "src/c4/charconv.hpp",
@@ -103,6 +104,7 @@ INSTRUCTIONS:
         "src/c4/span.hpp",
         "src/c4/type_name.hpp",
         "src/c4/base64.hpp",
+        am.onlyif(with_stl, am.ignfile("src/c4/std/std.hpp")), # this is an umbrella include
         am.onlyif(with_stl, "src/c4/std/span.hpp"),
         am.onlyif(with_stl, "src/c4/std/string.hpp"),
         am.onlyif(with_stl, "src/c4/std/string_view.hpp"),


### PR DESCRIPTION
  - `substr`:
    - improve SFINAE rules and overloads
    - add member type `value_type`
  - `type_name()`:
    - make `noexcept`
    - return a new dedicated type `TypeNameStr`. This spares costly include of span.hpp
  - Improve std interop headers
  - Fix: `from_chars_first()` must use `csubstr` for the chars parameters
  - clang-tidy fixes with clang-22

