### PR TITLE
C4_LIKELY now uses [[likely]] when possible

### DIFF
--- a/bm/bm_atox.cpp
+++ b/bm/bm_atox.cpp
@@ -11,7 +11,7 @@ bool range_based_restrictvar0(c4::csubstr s, T * v)
     *v = 0;
     for(char c : s)
     {
-        if(C4_UNLIKELY(c < '0' || c > '9'))
+        if C4_UNLIKELY(c < '0' || c > '9')
             return false;
         *v = (*v) * T(10) + (T(c) - T('0'));
     }
@@ -24,7 +24,7 @@ bool range_based_restrictvar1(c4::csubstr s, T *C4_RESTRICT v)
     *v = 0;
     for(char c : s)
     {
-        if(C4_UNLIKELY(c < '0' || c > '9'))
+        if C4_UNLIKELY(c < '0' || c > '9')
             return false;
         *v = (*v) * T(10) + (T(c) - T('0'));
     }
@@ -38,7 +38,7 @@ bool indexloop_restrictvar0(c4::csubstr s, T * v)
     for(size_t i = 0; i < s.len; ++i)
     {
         const char c = s.str[i];
-        if(C4_UNLIKELY(c < '0' || c > '9'))
+        if C4_UNLIKELY(c < '0' || c > '9')
             return false;
         *v = (*v) * T(10) + (T(c) - T('0'));
     }
@@ -52,7 +52,7 @@ bool indexloop_restrictvar1(c4::csubstr s, T *C4_RESTRICT v)
     for(size_t i = 0; i < s.len; ++i)
     {
         const char c = s.str[i];
-        if(C4_UNLIKELY(c < '0' || c > '9'))
+        if C4_UNLIKELY(c < '0' || c > '9')
             return false;
         *v = (*v) * T(10) + (T(c) - T('0'));
     }
@@ -65,7 +65,7 @@ bool prefer_likely(c4::csubstr s, T * v)
     *v = 0;
     for(char c : s)
     {
-        if(C4_LIKELY(c >= '0' && c <= '9'))
+        if C4_LIKELY(c >= '0' && c <= '9')
             *v = (*v) * T(10) + (T(c) - T('0'));
         else
             return false;
@@ -80,7 +80,7 @@ bool no_early_return(c4::csubstr s, T *C4_RESTRICT v)
     bool stat = true;
     for(char c : s)
     {
-        if(C4_LIKELY(c >= '0' && c <= '9'))
+        if C4_LIKELY(c >= '0' && c <= '9')
             *v = (*v) * T(10) + (T(c) - T('0'));
         else
         {
@@ -98,7 +98,7 @@ bool no_early_return_auto_type(c4::csubstr s, T *C4_RESTRICT v)
     bool stat = true;
     for(char c : s)
     {
-        if(C4_LIKELY(c >= '0' && c <= '9'))
+        if C4_LIKELY(c >= '0' && c <= '9')
             *v = (*v) * T(10) + (T)(c - '0');
         else
         {
@@ -116,7 +116,7 @@ bool no_early_return_auto_type2(c4::csubstr s, T *C4_RESTRICT v)
     bool stat = true;
     for(char c : s)
     {
-        if(C4_LIKELY(c >= '0' && c <= '9'))
+        if C4_LIKELY(c >= '0' && c <= '9')
         {
             *v *= 10;
             *v += (T)(c - '0');
@@ -399,7 +399,7 @@ C4_ALWAYS_INLINE auto unroll_switch(c4::csubstr s, T *C4_RESTRICT v)
         for( ; i + 10 < s.len; ++i)
         {
             *v = *v * T(10) + _(i);
-            if(C4_UNLIKELY(!ok(i)))
+            if C4_UNLIKELY(!ok(i))
                 return false;
         }
         *v = T(1000000000) * _(i) + T(100000000) * _(i+1) + T(10000000) * _(i+2) + T(1000000) * _(i+3) + T(100000) * _(i+4) + T(10000) * _(i+5) + T(1000) * _(i+6) + T(100) * _(i+7) + T(10) * _(i+8) + _(i+9);

--- a/bm/bm_xtoa.cpp
+++ b/bm/bm_xtoa.cpp
@@ -709,7 +709,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_divrem_write1(c4::substr buf, T v) no
     C4_ASSERT(v >= 0);
     size_t pos = 0;
     do {
-        if(C4_LIKELY(pos < buf.len))
+        if C4_LIKELY(pos < buf.len)
             buf.str[pos] = (char)('0' + (v % T(10)));
         ++pos;
         v /= T(10);
@@ -728,7 +728,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_divrem_write2(c4::substr buf, T v) no
 	{
         const auto num = (v % T(100)) << 1u;
         v /= T(100);
-        if(C4_LIKELY(pos + 2 < buf.len))
+        if C4_LIKELY(pos + 2 < buf.len)
         {
             buf.str[pos++] = digits0099[num + 1];
             buf.str[pos++] = digits0099[num];
@@ -737,7 +737,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_divrem_write2(c4::substr buf, T v) no
     if(v >= T(10))
 	{
         const auto num = v << 1u;
-        if(C4_LIKELY(pos + 2 < buf.len))
+        if C4_LIKELY(pos + 2 < buf.len)
         {
             buf.str[pos++] = digits0099[num + 1];
             buf.str[pos++] = digits0099[num];
@@ -745,7 +745,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_divrem_write2(c4::substr buf, T v) no
 	}
     else
     {
-        if(C4_LIKELY(pos < buf.len))
+        if C4_LIKELY(pos < buf.len)
             buf.str[pos++] = (char)('0' + v);
     }
     buf.reverse_range(0, pos);
@@ -765,7 +765,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_singlediv_write1(c4::substr buf, T v)
         const T quo = v / T(10);
         const auto rem = v - quo * T(10);
         v = quo;
-        if(C4_LIKELY(pos < buf.len))
+        if C4_LIKELY(pos < buf.len)
             buf.str[pos] = (char)('0' + rem);
         ++pos;
     } while(v);
@@ -784,7 +784,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_singlediv_write2(c4::substr buf, T v)
         const T quo = v / T(100);
         const auto num = (v - quo * T(100)) << 1u;
         v = quo;
-        if(C4_LIKELY(pos+2 < buf.len))
+        if C4_LIKELY(pos+2 < buf.len)
         {
             buf.str[pos++] = digits0099[num + 1];
             buf.str[pos++] = digits0099[num];
@@ -793,7 +793,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_singlediv_write2(c4::substr buf, T v)
     if(v >= T(10))
 	{
         const auto num = v << 1u;
-        if(C4_LIKELY(pos+2 < buf.len))
+        if C4_LIKELY(pos+2 < buf.len)
         {
             buf.str[pos++] = digits0099[num + 1];
             buf.str[pos++] = digits0099[num    ];
@@ -801,7 +801,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkall_singlediv_write2(c4::substr buf, T v)
 	}
     else
     {
-        if(C4_LIKELY(pos < buf.len))
+        if C4_LIKELY(pos < buf.len)
             buf.str[pos++] = (char)('0' + v);
     }
     buf.reverse_range(0, pos);
@@ -816,7 +816,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncemax_divrem_write1(c4::substr buf, T v
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
-    if(C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec))
+    if C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec)
         return c4::detail::charconv_digits<T>::maxdigits_dec;
     size_t pos = 0;
     do {
@@ -832,7 +832,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncemax_divrem_write2(c4::substr buf, T v
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
-    if(C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec))
+    if C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec)
         return c4::detail::charconv_digits<T>::maxdigits_dec;
     size_t pos = 0;
     while(v >= T(100))
@@ -864,7 +864,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncemax_singlediv_write1(c4::substr buf, 
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
-    if(C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec))
+    if C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec)
         return c4::detail::charconv_digits<T>::maxdigits_dec;
     size_t pos = 0;
     do {
@@ -883,7 +883,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncemax_singlediv_write2(c4::substr buf, 
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     size_t pos = 0;
-    if(C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec))
+    if C4_UNLIKELY(buf.len < c4::detail::charconv_digits<T>::maxdigits_dec)
         return c4::detail::charconv_digits<T>::maxdigits_dec;
     while(v >= T(100))
 	{
@@ -916,7 +916,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncelog_divrem_write1(c4::substr buf, T v
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digitsfunc(v);
-    if(C4_UNLIKELY(buf.len < digits))
+    if C4_UNLIKELY(buf.len < digits)
         return digits;
     size_t pos = digits;
     do {
@@ -932,7 +932,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncelog_divrem_write2(c4::substr buf, T v
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digitsfunc(v);
-    if(C4_UNLIKELY(buf.len < digits))
+    if C4_UNLIKELY(buf.len < digits)
         return digits;
     size_t pos = digits;
     while(v >= T(100))
@@ -964,7 +964,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncelog_singlediv_write1(c4::substr buf, 
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digitsfunc(v);
-    if(C4_UNLIKELY(buf.len < digits))
+    if C4_UNLIKELY(buf.len < digits)
         return digits;
     size_t pos = digits;
     do {
@@ -982,7 +982,7 @@ C4_ALWAYS_INLINE size_t write_dec_checkoncelog_singlediv_write2(c4::substr buf, 
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digitsfunc(v);
-    if(C4_UNLIKELY(buf.len < digits))
+    if C4_UNLIKELY(buf.len < digits)
         return digits;
     size_t pos = digits;
     while(v >= T(100))

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,3 +1,16 @@
 - [PR#169](https://github.com/biojppm/c4core/pull/169) atof()/atod():
   - disable assertions that prevent returning false
-- [PR#170](https://github.com/biojppm/c4core/pull/170) c4/std/std.hpp: remove tuple.hpp
+  - c4/std/std.hpp: remove tuple.hpp
+- [PR#171](https://github.com/biojppm/c4core/pull/171):
+  - fix warnings from names with underscores (clang: -Wreserved-identifier)
+  - c4/std/std.hpp: remove tuple.hpp
+- [PR#172](https://github.com/biojppm/c4core/pull/172):
+  - [**BREAKING**] `C4_LIKELY()` and `C4_UNLIKELY()` now use `[[likely]]` and `[[unlikely]]` in C++20. Every use of this macro needs to refactored:
+    ```c++
+    if(C4_LIKELY(condition)) ... // error now
+    // needs to be rewritten as:
+    if C4_LIKELY(condition)  ...
+    // same for C4_UNLIKELY
+    ```
+  - Add `C4_LIKELY20` and `C4_UNLIKELY20`, which resolve directly into `[[likely]]` and `[[unlikely]]` when C++ is 20 or later, or nothing otherwise.
+  - Add C++23 detection (`C4_CPP` and `C4_CPP23`)

--- a/src/c4/alloc.cpp
+++ b/src/c4/alloc.cpp
@@ -39,7 +39,7 @@ void* aalloc_impl(size_t size, size_t alignment) // NOLINT(misc-use-internal-lin
     // alignment must be nonzero and a power of 2
     C4_CHECK(alignment > 0 && (alignment & (alignment - 1u)) == 0);
     // NOTE: alignment needs to be sized in multiples of sizeof(void*)
-    if(C4_UNLIKELY(alignment < sizeof(void*)))
+    if C4_UNLIKELY(alignment < sizeof(void*))
         alignment = sizeof(void*);
     static_assert((sizeof(void*) & (sizeof(void*)-1u)) == 0, "sizeof(void*) must be a power of 2");
     C4_CHECK(((alignment & (sizeof(void*) - 1u))) == 0u);
@@ -49,7 +49,7 @@ void* aalloc_impl(size_t size, size_t alignment) // NOLINT(misc-use-internal-lin
     C4_CHECK(mem != nullptr || size == 0);
 #elif defined(C4_POSIX) || defined(C4_IOS) || defined(C4_MACOS)
     int ret = ::posix_memalign(&mem, alignment, size);
-    if(C4_UNLIKELY(ret))
+    if C4_UNLIKELY(ret)
     {
         C4_ASSERT(ret != EINVAL); // this was already handled above
         if(ret == ENOMEM)

--- a/src/c4/base64.cpp
+++ b/src/c4/base64.cpp
@@ -165,8 +165,8 @@ C4_HOT C4_ALWAYS_INLINE bool is_valid_encoded_group16_(const char *C4_RESTRICT c
     C4_ASSERT(!(num & 15)); // must be multiple of 16
     size_t rem = num;
     for( ; rem >= 16; rem -= 16, c += 16)
-        if(C4_UNLIKELY(!is_valid_encoded_group8_(c)
-                    || !is_valid_encoded_group8_(c + 8)))
+        if C4_UNLIKELY(!is_valid_encoded_group8_(c)
+                    || !is_valid_encoded_group8_(c + 8))
             return false;
     return true;
 }
@@ -449,21 +449,21 @@ bool base64_decode(char const* encoded_, size_t encoded_sz,
 #if (C4_WORDSIZE >= 8)
     for( ; rem >= 15; rem -= 12)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group16_(encoded, 16)))
+        if C4_UNLIKELY(!is_valid_encoded_group16_(encoded, 16))
             return false;
         base64_decode_block64_(encoded, data); encoded += 8; data += 6;
         base64_decode_block64_(encoded, data); encoded += 8; data += 6;
     }
     for( ; rem >= 9; rem -= 6)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group8_(encoded)))
+        if C4_UNLIKELY(!is_valid_encoded_group8_(encoded))
             return false;
         base64_decode_block64_(encoded, data); encoded += 8; data += 6;
     }
 #else
     for( ; rem >= 9; rem -= 6)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group8_(encoded)))
+        if C4_UNLIKELY(!is_valid_encoded_group8_(encoded))
             return false;
         base64_decode_block32_(encoded, data); encoded += 4; data += 3;
         base64_decode_block32_(encoded, data); encoded += 4; data += 3;
@@ -471,7 +471,7 @@ bool base64_decode(char const* encoded_, size_t encoded_sz,
 #endif
     for( ; rem >= 3; rem -= 3)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group4_(encoded)))
+        if C4_UNLIKELY(!is_valid_encoded_group4_(encoded))
             return false;
         base64_decode_block32_(encoded, data); encoded += 4; data += 3;
     }

--- a/src/c4/charconv.hpp
+++ b/src/c4/charconv.hpp
@@ -405,7 +405,7 @@ template<> struct charconv_digits_<8u, false> // uint64_t
 } // namespace detail
 
 // Helper macros, undefined below
-#define c4append_(c) { if(C4_LIKELY(pos < buf.len)) { buf.str[pos++] = static_cast<char>(c); } else { ++pos; } }
+#define c4append_(c) { if C4_LIKELY(pos < buf.len) { buf.str[pos++] = static_cast<char>(c); } else { ++pos; } }
 
 /** @endcond */
 
@@ -716,7 +716,7 @@ C4_ALWAYS_INLINE size_t write_dec(substr buf, T v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digits_dec(v);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_dec_unchecked(buf, v, digits);
     return digits;
 }
@@ -735,7 +735,7 @@ C4_ALWAYS_INLINE size_t write_hex(substr buf, T v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digits_hex(v);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_hex_unchecked(buf, v, digits);
     return digits;
 }
@@ -754,7 +754,7 @@ C4_ALWAYS_INLINE size_t write_oct(substr buf, T v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digits_oct(v);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_oct_unchecked(buf, v, digits);
     return digits;
 }
@@ -774,7 +774,7 @@ C4_ALWAYS_INLINE size_t write_bin(substr buf, T v) noexcept
     C4_ASSERT(v >= 0);
     unsigned digits = digits_bin(v);
     C4_ASSERT(digits > 0);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_bin_unchecked(buf, v, digits);
     return digits;
 }
@@ -878,7 +878,7 @@ C4_ALWAYS_INLINE bool read_dec(csubstr s, I *C4_RESTRICT v) noexcept
     *v = 0;
     for(char c : s)
     {
-        if(C4_UNLIKELY(c < '0' || c > '9'))
+        if C4_UNLIKELY(c < '0' || c > '9')
             return false;
         *v = ((*v) * I(10)) + (I(c) - I('0'));
     }
@@ -971,7 +971,7 @@ C4_ALWAYS_INLINE bool read_oct(csubstr s, I *C4_RESTRICT v) noexcept
     *v = 0;
     for(char c : s)
     {
-        if(C4_UNLIKELY(c < '0' || c > '7'))
+        if C4_UNLIKELY(c < '0' || c > '7')
             return false;
         *v = ((*v) * I(8)) + (I(c) - I('0'));
     }
@@ -1011,7 +1011,7 @@ template<class I>
 C4_NO_INLINE size_t _itoadec2buf(substr buf) noexcept
 {
     using digits_type = detail::charconv_digits<I>;
-    if(C4_UNLIKELY(buf.len < digits_type::maxdigits_dec))
+    if C4_UNLIKELY(buf.len < digits_type::maxdigits_dec)
         return digits_type::maxdigits_dec;
     buf.str[0] = '-';
     return detail::_itoa2buf(buf, 1, digits_type::min_value_dec());
@@ -1021,31 +1021,31 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix) noexcept
 {
     using digits_type = detail::charconv_digits<I>;
     size_t pos = 0;
-    if(C4_LIKELY(buf.len > 0))
+    if C4_LIKELY(buf.len > 0)
         buf.str[pos++] = '-';
     switch(radix) // NOLINT(hicpp-multiway-paths-covered)
     {
     case I(10):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_dec))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_dec)
             return digits_type::maxdigits_dec;
         pos =_itoa2buf(buf, pos, digits_type::min_value_dec());
         break;
     case I(16):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_hex))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_hex)
             return digits_type::maxdigits_hex;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'x';
         pos = _itoa2buf(buf, pos, digits_type::min_value_hex());
         break;
     case I( 2):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_bin))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_bin)
             return digits_type::maxdigits_bin;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'b';
         pos = _itoa2buf(buf, pos, digits_type::min_value_bin());
         break;
     case I( 8):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_oct))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_oct)
             return digits_type::maxdigits_oct;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'o';
@@ -1060,21 +1060,21 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix, size_t num_digits) noexcept
     using digits_type = detail::charconv_digits<I>;
     size_t pos = 0;
     size_t needed_digits = 0;
-    if(C4_LIKELY(buf.len > 0))
+    if C4_LIKELY(buf.len > 0)
         buf.str[pos++] = '-';
     switch(radix) // NOLINT(hicpp-multiway-paths-covered)
     {
     case I(10):
         // add 1 to account for -
         needed_digits = num_digits+1 > digits_type::maxdigits_dec ? num_digits+1 : digits_type::maxdigits_dec;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         pos = _itoa2bufwithdigits(buf, pos, num_digits, digits_type::min_value_dec());
         break;
     case I(16):
         // add 3 to account for -0x
         needed_digits = num_digits+3 > digits_type::maxdigits_hex ? num_digits+3 : digits_type::maxdigits_hex;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'x';
@@ -1083,7 +1083,7 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix, size_t num_digits) noexcept
     case I(2):
         // add 3 to account for -0b
         needed_digits = num_digits+3 > digits_type::maxdigits_bin ? num_digits+3 : digits_type::maxdigits_bin;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         C4_ASSERT(buf.len >= digits_type::maxdigits_bin);
         buf.str[pos++] = '0';
@@ -1093,7 +1093,7 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix, size_t num_digits) noexcept
     case I(8):
         // add 3 to account for -0o
         needed_digits = num_digits+3 > digits_type::maxdigits_oct ? num_digits+3 : digits_type::maxdigits_oct;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         C4_ASSERT(buf.len >= digits_type::maxdigits_oct);
         buf.str[pos++] = '0';
@@ -1127,11 +1127,11 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v) noexcept
     }
     // when T is the min value (eg i8: -128), negating it
     // will overflow, so treat the min as a special case
-    if(C4_LIKELY(v != std::numeric_limits<T>::min()))
+    if C4_LIKELY(v != std::numeric_limits<T>::min())
     {
         v = (T)-v;
         unsigned digits = digits_dec(v);
-        if(C4_LIKELY(buf.len >= digits + 1u))
+        if C4_LIKELY(buf.len >= digits + 1u)
         {
             buf.str[0] = '-';
             write_dec_unchecked(buf.sub(1), v, digits);
@@ -1159,13 +1159,13 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
     #endif
     // when T is the min value (eg i8: -128), negating it
     // will overflow, so treat the min as a special case
-    if(C4_LIKELY(v != std::numeric_limits<T>::min()))
+    if C4_LIKELY(v != std::numeric_limits<T>::min())
     {
         unsigned pos = 0;
         if(v < 0)
         {
             v = (T)-v;
-            if(C4_LIKELY(buf.len > 0))
+            if C4_LIKELY(buf.len > 0)
                 buf.str[pos] = '-';
             ++pos;
         }
@@ -1174,12 +1174,12 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
         {
         case T(10):
             digits = digits_dec(v);
-            if(C4_LIKELY(buf.len >= pos + digits))
+            if C4_LIKELY(buf.len >= pos + digits)
                 write_dec_unchecked(buf.sub(pos), v, digits);
             break;
         case T(16):
             digits = digits_hex(v);
-            if(C4_LIKELY(buf.len >= pos + 2u + digits))
+            if C4_LIKELY(buf.len >= pos + 2u + digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'x';
@@ -1189,7 +1189,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
             break;
         case T(2):
             digits = digits_bin(v);
-            if(C4_LIKELY(buf.len >= pos + 2u + digits))
+            if C4_LIKELY(buf.len >= pos + 2u + digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'b';
@@ -1199,7 +1199,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
             break;
         case T(8):
             digits = digits_oct(v);
-            if(C4_LIKELY(buf.len >= pos + 2u + digits))
+            if C4_LIKELY(buf.len >= pos + 2u + digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'o';
@@ -1236,13 +1236,13 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
     #endif
     // when T is the min value (eg i8: -128), negating it
     // will overflow, so treat the min as a special case
-    if(C4_LIKELY(v != std::numeric_limits<T>::min()))
+    if C4_LIKELY(v != std::numeric_limits<T>::min())
     {
         unsigned pos = 0;
         if(v < 0)
         {
             v = (T)-v;
-            if(C4_LIKELY(buf.len > 0))
+            if C4_LIKELY(buf.len > 0)
                 buf.str[pos] = '-';
             ++pos;
         }
@@ -1252,13 +1252,13 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
         case T(10):
             total_digits = digits_dec(v);
             total_digits = pos + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
                 write_dec(buf.sub(pos), v, num_digits);
             break;
         case T(16):
             total_digits = digits_hex(v);
             total_digits = pos + 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'x';
@@ -1268,7 +1268,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
         case T(2):
             total_digits = digits_bin(v);
             total_digits = pos + 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'b';
@@ -1278,7 +1278,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
         case T(8):
             total_digits = digits_oct(v);
             total_digits = pos + 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'o';
@@ -1336,12 +1336,12 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix) noexcept
     {
     case T(10):
         digits = digits_dec(v);
-        if(C4_LIKELY(buf.len >= digits))
+        if C4_LIKELY(buf.len >= digits)
             write_dec_unchecked(buf, v, digits);
         break;
     case T(16):
         digits = digits_hex(v);
-        if(C4_LIKELY(buf.len >= digits+2u))
+        if C4_LIKELY(buf.len >= digits+2u)
         {
             buf.str[0] = '0';
             buf.str[1] = 'x';
@@ -1351,7 +1351,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix) noexcept
         break;
     case T(2):
         digits = digits_bin(v);
-        if(C4_LIKELY(buf.len >= digits+2u))
+        if C4_LIKELY(buf.len >= digits+2u)
         {
             buf.str[0] = '0';
             buf.str[1] = 'b';
@@ -1361,7 +1361,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix) noexcept
         break;
     case T(8):
         digits = digits_oct(v);
-        if(C4_LIKELY(buf.len >= digits+2u))
+        if C4_LIKELY(buf.len >= digits+2u)
         {
             buf.str[0] = '0';
             buf.str[1] = 'o';
@@ -1392,13 +1392,13 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix, size_t num_digits) noexce
     case T(10):
         total_digits = digits_dec(v);
         total_digits = (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
             write_dec(buf, v, num_digits);
         break;
     case T(16):
         total_digits = digits_hex(v);
         total_digits = 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
         {
             buf.str[0] = '0';
             buf.str[1] = 'x';
@@ -1408,7 +1408,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix, size_t num_digits) noexce
     case T(2):
         total_digits = digits_bin(v);
         total_digits = 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
         {
             buf.str[0] = '0';
             buf.str[1] = 'b';
@@ -1418,7 +1418,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix, size_t num_digits) noexce
     case T(8):
         total_digits = digits_oct(v);
         total_digits = 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
         {
             buf.str[0] = '0';
             buf.str[1] = 'o';
@@ -1468,7 +1468,7 @@ C4_ALWAYS_INLINE bool atoi(csubstr str, T * C4_RESTRICT v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_STATIC_ASSERT(std::is_signed<T>::value);
 
-    if(C4_UNLIKELY(str.len == 0))
+    if C4_UNLIKELY(str.len == 0)
         return false;
     // no need for the assertion, but we leave it here to document
     // the expectation:
@@ -1478,7 +1478,7 @@ C4_ALWAYS_INLINE bool atoi(csubstr str, T * C4_RESTRICT v) noexcept
     size_t start = 0;
     if(str.str[0] == '-')
     {
-        if(C4_UNLIKELY(str.len == ++start))
+        if C4_UNLIKELY(str.len == ++start)
             return false;
         sign = -1;
     }
@@ -1505,7 +1505,7 @@ C4_ALWAYS_INLINE bool atoi(csubstr str, T * C4_RESTRICT v) noexcept
     {
         parsed_ok = read_dec(str.sub(start), v);
     }
-    if(C4_LIKELY(parsed_ok))
+    if C4_LIKELY(parsed_ok)
         *v *= sign;
     return parsed_ok;
 }
@@ -1559,7 +1559,7 @@ bool atou(csubstr str, T * C4_RESTRICT v) noexcept
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
 
-    if(C4_UNLIKELY(str.len == 0 || str.front() == '-'))
+    if C4_UNLIKELY(str.len == 0 || str.front() == '-')
         return false;
 
     bool parsed_ok = true;
@@ -1656,7 +1656,7 @@ auto overflows(csubstr str) noexcept
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
 
-    if(C4_UNLIKELY(str.len == 0))
+    if C4_UNLIKELY(str.len == 0)
     {
         return false;
     }
@@ -1699,7 +1699,7 @@ auto overflows(csubstr str) noexcept
             }
         }
     }
-    else if(C4_UNLIKELY(str.str[0] == '-'))
+    else if C4_UNLIKELY(str.str[0] == '-')
     {
         return true;
     }
@@ -1722,7 +1722,7 @@ auto overflows(csubstr str) noexcept
     -> typename std::enable_if<std::is_signed<T>::value, bool>::type
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
-    if(C4_UNLIKELY(str.len == 0))
+    if C4_UNLIKELY(str.len == 0)
         return false;
     if(str.str[0] == '-')
     {
@@ -2031,14 +2031,14 @@ C4_ALWAYS_INLINE bool scan_rhex(csubstr s, T *C4_RESTRICT val) noexcept
     }
     return true;
 power:
-    if(C4_LIKELY(pos < s.len))
+    if C4_LIKELY(pos < s.len)
     {
         if(s.str[pos] == '+') // atoi() cannot handle a leading '+'
             ++pos;
-        if(C4_LIKELY(pos < s.len))
+        if C4_LIKELY(pos < s.len)
         {
             int16_t powval = {};
-            if(C4_LIKELY(atoi(s.sub(pos), &powval)))
+            if C4_LIKELY(atoi(s.sub(pos), &powval))
             {
                 *val *= ipow<T, int16_t, 16>(powval);
                 return true;
@@ -2499,7 +2499,7 @@ inline bool from_chars(csubstr buf, bool * C4_RESTRICT v) noexcept
     // fallback to c-style int bools
     int val = 0;
     bool ret = from_chars(buf, &val);
-    if(C4_LIKELY(ret))
+    if C4_LIKELY(ret)
     {
         *v = (val != 0);
     }
@@ -2638,7 +2638,7 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
 {
     csubstr trimmed = buf.first_non_empty_span();
     C4_ASSERT(!trimmed.overlaps(*v));
-    if(C4_UNLIKELY(trimmed.len == 0))
+    if C4_UNLIKELY(trimmed.len == 0)
         return csubstr::npos;
     size_t len = trimmed.len > v->len ? v->len : trimmed.len;
     // calling memcpy with zero len is undefined behavior
@@ -2650,7 +2650,7 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
         C4_ASSERT(v->str != nullptr);
         memcpy(v->str, trimmed.str, len);
     }
-    if(C4_UNLIKELY(trimmed.len > v->len))
+    if C4_UNLIKELY(trimmed.len > v->len)
         return csubstr::npos;
     return static_cast<size_t>(trimmed.end() - buf.begin());
 }

--- a/src/c4/dump.hpp
+++ b/src/c4/dump.hpp
@@ -117,7 +117,7 @@ size_t dump(substr buf, Arg const& a)
         // serialize to the buffer
         const size_t sz = to_chars(buf, a);
         // dump the buffer to the sink
-        if(C4_LIKELY(sz <= buf.len))
+        if C4_LIKELY(sz <= buf.len)
         {
             // NOTE: don't do this:
             //sinkfn(buf.first(sz));
@@ -171,7 +171,7 @@ size_t dump(SinkFn &&sinkfn, substr buf, Arg const& a)
         // serialize to the buffer
         const size_t sz = to_chars(buf, a);
         // dump the buffer to the sink
-        if(C4_LIKELY(sz <= buf.len))
+        if C4_LIKELY(sz <= buf.len)
         {
             // NOTE: don't do this:
             //std::forward<SinkFn>(sinkfn)(buf.first(sz));
@@ -218,7 +218,7 @@ inline auto dump(substr buf, Arg const& a)
     // serialize to the buffer
     const size_t sz = to_chars(buf, a);
     // dump the buffer to the sink
-    if(C4_LIKELY(sz <= buf.len))
+    if C4_LIKELY(sz <= buf.len)
     {
         // NOTE: don't do this:
         //sinkfn(buf.first(sz));
@@ -237,7 +237,7 @@ inline auto dump(SinkFn &&sinkfn, substr buf, Arg const& a)
     // serialize to the buffer
     const size_t sz = to_chars(buf, a);
     // dump the buffer to the sink
-    if(C4_LIKELY(sz <= buf.len))
+    if C4_LIKELY(sz <= buf.len)
     {
         // NOTE: don't do this:
         //std::forward<SinkFn>(sinkfn)(buf.first(sz));
@@ -322,7 +322,7 @@ template<class SinkFn, class Arg, class... Args>
 size_t cat_dump(SinkFn &&sinkfn, substr buf, Arg const& a, Args const& ...more)
 {
     const size_t size_for_a = dump(std::forward<SinkFn>(sinkfn), buf, a);
-    if(C4_UNLIKELY(size_for_a > buf.len))
+    if C4_UNLIKELY(size_for_a > buf.len)
         buf.len = 0; // ensure no more calls to the sink
     const size_t size_for_more = cat_dump(std::forward<SinkFn>(sinkfn), buf, more...);
     return size_for_more > size_for_a ? size_for_more : size_for_a;
@@ -348,7 +348,7 @@ template<SinkPfn sinkfn, class Arg, class... Args>
 size_t cat_dump(substr buf, Arg const& a, Args const& ...more)
 {
     const size_t size_for_a = dump<sinkfn>(buf, a);
-    if(C4_UNLIKELY(size_for_a > buf.len))
+    if C4_UNLIKELY(size_for_a > buf.len)
         buf.len = 0; // ensure no more calls to the sink
     const size_t size_for_more = cat_dump<sinkfn>(buf, more...);
     return size_for_more > size_for_a ? size_for_more : size_for_a;
@@ -379,7 +379,7 @@ C4_ALWAYS_INLINE DumpResults cat_dump_resume(size_t, SinkFn &&, DumpResults resu
 template<SinkPfn sinkfn, class Arg, class... Args>
 DumpResults cat_dump_resume(size_t currarg, DumpResults results, substr buf, Arg const& C4_RESTRICT a, Args const& ...more)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         size_t sz = dump<sinkfn>(buf, a);  // yield to the specialized function
         if(currarg == results.lastok + 1 && sz <= buf.len)
@@ -392,7 +392,7 @@ DumpResults cat_dump_resume(size_t currarg, DumpResults results, substr buf, Arg
 template<class SinkFn, class Arg, class... Args>
 DumpResults cat_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults results, substr buf, Arg const& C4_RESTRICT a, Args const& ...more)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         size_t sz = dump(std::forward<SinkFn>(sinkfn), buf, a);  // yield to the specialized function
         if(currarg == results.lastok + 1 && sz <= buf.len)
@@ -462,12 +462,12 @@ template<class SinkFn, class Sep, class Arg, class... Args>
 size_t catsep_dump(SinkFn &&sinkfn, substr buf, Sep const& sep, Arg const& a, Args const& ...more)
 {
     size_t sz = dump(std::forward<SinkFn>(sinkfn), buf, a);
-    if(C4_UNLIKELY(sz > buf.len))
+    if C4_UNLIKELY(sz > buf.len)
         buf.len = 0; // ensure no more calls
     if C4_IF_CONSTEXPR (sizeof...(more) > 0)
     {
         size_t szsep = dump(std::forward<SinkFn>(sinkfn), buf, sep);
-        if(C4_UNLIKELY(szsep > buf.len))
+        if C4_UNLIKELY(szsep > buf.len)
             buf.len = 0; // ensure no more calls
         sz = sz > szsep ? sz : szsep;
     }
@@ -480,12 +480,12 @@ template<SinkPfn sinkfn, class Sep, class Arg, class... Args>
 size_t catsep_dump(substr buf, Sep const& sep, Arg const& a, Args const& ...more)
 {
     size_t sz = dump<sinkfn>(buf, a);
-    if(C4_UNLIKELY(sz > buf.len))
+    if C4_UNLIKELY(sz > buf.len)
         buf.len = 0; // ensure no more calls
     if C4_IF_CONSTEXPR (sizeof...(more) > 0)
     {
         size_t szsep = dump<sinkfn>(buf, sep);
-        if(C4_UNLIKELY(szsep > buf.len))
+        if C4_UNLIKELY(szsep > buf.len)
             buf.len = 0; // ensure no more calls
         sz = sz > szsep ? sz : szsep;
     }
@@ -503,11 +503,11 @@ namespace detail {
 template<SinkPfn sinkfn, class Arg>
 void catsep_dump_resume_(size_t currarg, DumpResults *C4_RESTRICT results, substr *buf, Arg const& a)
 {
-    if(C4_LIKELY(results->write_arg(currarg)))
+    if C4_LIKELY(results->write_arg(currarg))
     {
         size_t sz = dump<sinkfn>(*buf, a);
         results->bufsize = sz > results->bufsize ? sz : results->bufsize;
-        if(C4_LIKELY(sz <= buf->len))
+        if C4_LIKELY(sz <= buf->len)
             results->lastok = currarg;
         else
             buf->len = 0;
@@ -517,11 +517,11 @@ void catsep_dump_resume_(size_t currarg, DumpResults *C4_RESTRICT results, subst
 template<class SinkFn, class Arg>
 void catsep_dump_resume_(size_t currarg, SinkFn &&sinkfn, DumpResults *C4_RESTRICT results, substr *C4_RESTRICT buf, Arg const& C4_RESTRICT a)
 {
-    if(C4_LIKELY(results->write_arg(currarg)))
+    if C4_LIKELY(results->write_arg(currarg))
     {
         size_t sz = dump(std::forward<SinkFn>(sinkfn), *buf, a);
         results->bufsize = sz > results->bufsize ? sz : results->bufsize;
-        if(C4_LIKELY(sz <= buf->len))
+        if C4_LIKELY(sz <= buf->len)
             results->lastok = currarg;
         else
             buf->len = 0;
@@ -650,7 +650,7 @@ C4_NO_INLINE size_t format_dump(SinkFn &&sinkfn, substr buf, csubstr fmt, Arg co
     // we can dump without using buf
     // but we'll only dump if the buffer is ok
     size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
     {
         std::forward<SinkFn>(sinkfn)(fmt);
         return 0u;
@@ -660,7 +660,7 @@ C4_NO_INLINE size_t format_dump(SinkFn &&sinkfn, substr buf, csubstr fmt, Arg co
     pos = dump(std::forward<SinkFn>(sinkfn), buf, a); // reuse pos to get needed_size
     // dump no more if the buffer was exhausted
     size_t size_for_more;
-    if(C4_LIKELY(pos <= buf.len))
+    if C4_LIKELY(pos <= buf.len)
         size_for_more = format_dump(std::forward<SinkFn>(sinkfn), buf, fmt, more...);
     else
         size_for_more = detail::_format_dump_compute_size(more...);
@@ -674,7 +674,7 @@ C4_NO_INLINE size_t format_dump(substr buf, csubstr fmt, Arg const& C4_RESTRICT 
     // we can dump without using buf
     // but we'll only dump if the buffer is ok
     size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
     {
         sinkfn(fmt);
         return 0u;
@@ -684,7 +684,7 @@ C4_NO_INLINE size_t format_dump(substr buf, csubstr fmt, Arg const& C4_RESTRICT 
     pos = dump<sinkfn>(buf, a); // reuse pos to get needed_size
     // dump no more if the buffer was exhausted
     size_t size_for_more;
-    if(C4_LIKELY(pos <= buf.len))
+    if C4_LIKELY(pos <= buf.len)
         size_for_more = format_dump<sinkfn>(buf, fmt, more...);
     else
         size_for_more = detail::_format_dump_compute_size(more...);
@@ -702,7 +702,7 @@ namespace detail {
 template<SinkPfn sinkfn>
 DumpResults format_dump_resume(size_t currarg, DumpResults results, substr, csubstr fmt)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         // we can dump without using buf
         sinkfn(fmt);
@@ -715,7 +715,7 @@ DumpResults format_dump_resume(size_t currarg, DumpResults results, substr, csub
 template<class SinkFn>
 DumpResults format_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults results, substr, csubstr fmt)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         // we can dump without using buf
         std::forward<SinkFn>(sinkfn)(fmt);
@@ -730,18 +730,18 @@ DumpResults format_dump_resume(size_t currarg, DumpResults results, substr buf, 
     // we need to process the format even if we're not
     // going to print the first arguments because we're resuming
     const size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_LIKELY(pos != csubstr::npos))
+    if C4_LIKELY(pos != csubstr::npos)
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             sinkfn(fmt.first(pos));
             results.lastok = currarg;
         }
-        if(C4_LIKELY(results.write_arg(currarg + 1u)))
+        if C4_LIKELY(results.write_arg(currarg + 1u))
         {
             const size_t len = dump<sinkfn>(buf, a);
             results.bufsize = len > results.bufsize ? len : results.bufsize;
-            if(C4_LIKELY(len <= buf.len))
+            if C4_LIKELY(len <= buf.len)
             {
                 results.lastok = currarg + 1u;
             }
@@ -755,7 +755,7 @@ DumpResults format_dump_resume(size_t currarg, DumpResults results, substr buf, 
     }
     else
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             sinkfn(fmt);
             results.lastok = currarg;
@@ -775,18 +775,18 @@ DumpResults format_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults resu
     // we need to process the format even if we're not
     // going to print the first arguments because we're resuming
     const size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_LIKELY(pos != csubstr::npos))
+    if C4_LIKELY(pos != csubstr::npos)
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             std::forward<SinkFn>(sinkfn)(fmt.first(pos));
             results.lastok = currarg;
         }
-        if(C4_LIKELY(results.write_arg(currarg + 1u)))
+        if C4_LIKELY(results.write_arg(currarg + 1u))
         {
             const size_t len = dump(std::forward<SinkFn>(sinkfn), buf, a);
             results.bufsize = len > results.bufsize ? len : results.bufsize;
-            if(C4_LIKELY(len <= buf.len))
+            if C4_LIKELY(len <= buf.len)
             {
                 results.lastok = currarg + 1u;
             }
@@ -800,7 +800,7 @@ DumpResults format_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults resu
     }
     else
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             std::forward<SinkFn>(sinkfn)(fmt);
             results.lastok = currarg;

--- a/src/c4/error.hpp
+++ b/src/c4/error.hpp
@@ -333,7 +333,7 @@ C4CORE_EXPORT void handle_warning(srcloc s, const char *fmt, ...);
  */
 #define C4_CHECK(cond)                              \
     do {                                            \
-        if(C4_UNLIKELY(!(cond)))                    \
+        if C4_UNLIKELY(!(cond))                     \
         {                                           \
             C4_ERROR("check failed: %s", #cond);    \
         }                                           \
@@ -345,7 +345,7 @@ C4CORE_EXPORT void handle_warning(srcloc s, const char *fmt, ...);
  * @ingroup error_checking */
 #define C4_CHECK_MSG(cond, fmt, ...)                                    \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             C4_ERROR("check failed: " #cond "\n" fmt, ## __VA_ARGS__);  \
         }                                                               \

--- a/src/c4/format.hpp
+++ b/src/c4/format.hpp
@@ -321,7 +321,7 @@ C4_ALWAYS_INLINE auto to_chars(substr buf, fmt::integral_padded_<T> fmt)
 template<class T>
 C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> wrapper)
 {
-    if(C4_LIKELY(!overflows<T>(s)))
+    if C4_LIKELY(!overflows<T>(s))
         return atox(s, wrapper.val);
     return false;
 }
@@ -330,7 +330,7 @@ C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> wrapper)
 template<class T>
 C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> *wrapper)
 {
-    if(C4_LIKELY(!overflows<T>(s)))
+    if C4_LIKELY(!overflows<T>(s))
         return atox(s, wrapper->val);
     return false;
 }
@@ -690,11 +690,11 @@ template<class Arg, class... Args>
 size_t uncat(csubstr buf, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
     size_t out = from_chars_first(buf, &a);
-    if(C4_UNLIKELY(out == csubstr::npos))
+    if C4_UNLIKELY(out == csubstr::npos)
         return csubstr::npos;
     buf  = buf.len >= out ? buf.sub(out) : substr{};
     size_t num = uncat(buf, more...);
-    if(C4_UNLIKELY(num == csubstr::npos))
+    if C4_UNLIKELY(num == csubstr::npos)
         return csubstr::npos;
     return out + num;
 }
@@ -818,16 +818,16 @@ inline size_t uncatsep(csubstr buf, csubstr /*sep*/, Arg &C4_RESTRICT a)
 template<class Arg, class... Args>
 size_t uncatsep(csubstr buf, csubstr sep, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
-    if(C4_LIKELY(sep.len > 0))
+    if C4_LIKELY(sep.len > 0)
     {
         size_t pos = buf.find(sep);
-        if(C4_LIKELY(pos != csubstr::npos))
+        if C4_LIKELY(pos != csubstr::npos)
         {
-            if(C4_LIKELY(from_chars(buf.first(pos), &a)))
+            if C4_LIKELY(from_chars(buf.first(pos), &a))
             {
                 pos += sep.len;
                 size_t num = uncatsep(buf.sub(pos), sep, more...);
-                if(C4_LIKELY(num != csubstr::npos))
+                if C4_LIKELY(num != csubstr::npos)
                     return pos + num;
             }
         }
@@ -936,7 +936,7 @@ template<class Arg, class... Args>
 size_t format(substr buf, csubstr fmt, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more)
 {
     size_t pos = fmt.find("{}");
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
         return to_chars(buf, fmt);
     size_t num = to_chars(buf, fmt.first(pos));
     size_t out = num;
@@ -987,18 +987,18 @@ template<class Arg, class... Args>
 size_t unformat(csubstr buf, csubstr fmt, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
     const size_t pos = fmt.find("{}");
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
         return unformat(buf, fmt);
     size_t num = pos;
     size_t out = num;
     buf  = buf.len >= num ? buf.sub(num) : substr{};
     num  = from_chars_first(buf, &a);
-    if(C4_UNLIKELY(num == csubstr::npos))
+    if C4_UNLIKELY(num == csubstr::npos)
         return csubstr::npos;
     out += num;
     buf  = buf.len >= num ? buf.sub(num) : substr{};
     num  = unformat(buf, fmt.sub(pos + 2), more...);
-    if(C4_UNLIKELY(num == csubstr::npos))
+    if C4_UNLIKELY(num == csubstr::npos)
         return csubstr::npos;
     out += num;
     return out;

--- a/src/c4/language.hpp
+++ b/src/c4/language.hpp
@@ -195,6 +195,7 @@
 #define C4_BEGIN_HIDDEN_NAMESPACE namespace /*hidden*/ {
 #define C4_END_HIDDEN_NAMESPACE } /* namespace hidden */
 
+
 //------------------------------------------------------------
 
 #ifndef C4_API
@@ -224,8 +225,6 @@
 #   define C4_COLD        /** @todo */
 #   define C4_ASSUME(...) __assume(__VA_ARGS__)
 #   define C4_EXPECT(x, y) x /** @todo */
-#   define C4_LIKELY(x)   x
-#   define C4_UNLIKELY(x) x
 #   define C4_UNREACHABLE() _c4_msvc_unreachable()
 #   define C4_ATTR_FORMAT(...) /** */
 #   define C4_NORETURN [[noreturn]]
@@ -263,8 +262,6 @@
  * @see http://stackoverflow.com/questions/15028990/semantics-of-gcc-hot-attribute */
 #   define C4_COLD __attribute__((cold))
 #   define C4_EXPECT(x, y) __builtin_expect(x, y) ///< @see https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
-#   define C4_LIKELY(x)   __builtin_expect(x, 1)
-#   define C4_UNLIKELY(x) __builtin_expect(x, 0)
 #   define C4_UNREACHABLE() __builtin_unreachable()
 #   define C4_ATTR_FORMAT(...) //__attribute__((format (__VA_ARGS__))) ///< @see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
 #   define C4_NORETURN __attribute__((noreturn))
@@ -305,6 +302,30 @@
 #   ifndef C4_ASSUME
 #       define C4_ASSUME(...)
 #   endif
+#endif
+
+
+#ifdef __has_cpp_attribute
+#   if (__has_cpp_attribute(unlikely) >= 201803L) && (C4_CPP >= 20)
+#       define C4_UNLIKELY_IS_ATTR_
+#   endif
+#endif
+
+#ifdef C4_UNLIKELY_IS_ATTR_
+#   define C4_LIKELY(x)   (x) [[likely]]
+#   define C4_UNLIKELY(x) (x) [[unlikely]]
+#   define C4_LIKELY20   [[likely]]
+#   define C4_UNLIKELY20 [[unlikely]]
+#elif defined(__clang__) || defined(__GNUC__)
+#   define C4_LIKELY(x)   (__builtin_expect(x, 1))
+#   define C4_UNLIKELY(x) (__builtin_expect(x, 0))
+#   define C4_LIKELY20
+#   define C4_UNLIKELY20
+#elif defined(_MSC_VER)
+#   define C4_LIKELY(x)   (x)
+#   define C4_UNLIKELY(x) (x)
+#   define C4_LIKELY20
+#   define C4_UNLIKELY20
 #endif
 
 

--- a/src/c4/language.hpp
+++ b/src/c4/language.hpp
@@ -18,45 +18,39 @@
 #           if (!defined(_MSVC_LANG))
 #               error _MSVC not defined
 #           endif
-#           if _MSVC_LANG >= 201705L
+#           if _MSVC_LANG >= 202302L
+#               define C4_CPP 23
+#           elif _MSVC_LANG >= 202002L
 #               define C4_CPP 20
-#               define C4_CPP20
 #           elif _MSVC_LANG == 201703L
 #               define C4_CPP 17
-#               define C4_CPP17
 #           elif _MSVC_LANG >= 201402L
 #               define C4_CPP 14
-#               define C4_CPP14
 #           elif _MSVC_LANG >= 201103L
 #               define C4_CPP 11
-#               define C4_CPP11
 #           else
 #               error C++ lesser than C++11 not supported
 #           endif
 #       else
 #           if _MSC_VER == 1900
 #               define C4_CPP 14  // VS2015 is c++14 https://devblogs.microsoft.com/cppblog/c111417-features-in-vs-2015-rtm/
-#               define C4_CPP14
 #           elif _MSC_VER == 1800 // VS2013
 #               define C4_CPP 11
-#               define C4_CPP11
 #           else
 #               error C++ lesser than C++11 not supported
 #           endif
 #       endif
-#   elif defined(__INTEL_COMPILER) // https://software.intel.com/en-us/node/524490
-#       ifdef __INTEL_CXX20_MODE__ // not sure about this
+#   elif defined(__INTEL_COMPILER) // not sure about this https://software.intel.com/en-us/node/524490
+#       ifdef __INTEL_CXX23_MODE__
+#           define C4_CPP 23
+#       elif defined __INTEL_CXX20_MODE__
 #           define C4_CPP 20
-#           define C4_CPP20
-#       elif defined __INTEL_CXX17_MODE__ // not sure about this
+#       elif defined __INTEL_CXX17_MODE__
 #           define C4_CPP 17
-#           define C4_CPP17
-#       elif defined __INTEL_CXX14_MODE__ // not sure about this
+#       elif defined __INTEL_CXX14_MODE__
 #           define C4_CPP 14
-#           define C4_CPP14
 #       elif defined __INTEL_CXX11_MODE__
 #           define C4_CPP 11
-#           define C4_CPP11
 #       else
 #           error C++ lesser than C++11 not supported
 #       endif
@@ -66,49 +60,37 @@
 #       endif
 #       if __cplusplus == 1
 #           error cannot handle __cplusplus==1
-#       elif __cplusplus >= 201709L
+#       elif __cplusplus >= 202302L
+#           define C4_CPP 23
+#       elif __cplusplus >= 202002L
 #           define C4_CPP 20
-#           define C4_CPP20
 #       elif __cplusplus >= 201703L
 #           define C4_CPP 17
-#           define C4_CPP17
 #       elif __cplusplus >= 201402L
 #           define C4_CPP 14
-#           define C4_CPP14
 #       elif __cplusplus >= 201103L
 #           define C4_CPP 11
-#           define C4_CPP11
 #       elif __cplusplus >= 199711L
 #           error C++ lesser than C++11 not supported
 #       endif
 #   endif
-#else
-#   ifdef C4_CPP == 20
-#       define C4_CPP20
-#   elif C4_CPP == 17
-#       define C4_CPP17
-#   elif C4_CPP == 14
-#       define C4_CPP14
-#   elif C4_CPP == 11
-#       define C4_CPP11
-#   elif C4_CPP == 98
-#       define C4_CPP98
-#       error C++ lesser than C++11 not supported
-#   else
-#       error C4_CPP must be one of 20, 17, 14, 11, 98
-#   endif
+#endif
+#if C4_CPP >= 23
+#   define C4_CPP23
+#endif
+#if C4_CPP >= 20
+#   define C4_CPP20
+#endif
+#if C4_CPP >= 17
+#   define C4_CPP17
+#endif
+#if C4_CPP >= 14
+#   define C4_CPP14
+#endif
+#if C4_CPP >= 11
+#   define C4_CPP11
 #endif
 
-#ifdef C4_CPP20
-#   define C4_CPP17
-#   define C4_CPP14
-#   define C4_CPP11
-#elif defined(C4_CPP17)
-#   define C4_CPP14
-#   define C4_CPP11
-#elif defined(C4_CPP14)
-#   define C4_CPP11
-#endif
 
 /** lifted from this answer: http://stackoverflow.com/a/20170989/5875572 */
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/src/c4/memory_util.cpp
+++ b/src/c4/memory_util.cpp
@@ -8,7 +8,7 @@ namespace c4 {
 void mem_repeat(void* dest, void const* pattern, size_t pattern_size, size_t num_times)
 {
     C4_ASSERT( ! mem_overlaps(dest, pattern, num_times*pattern_size, pattern_size));
-    if(C4_UNLIKELY(num_times == 0))
+    if C4_UNLIKELY(num_times == 0)
         return;
     char *C4_RESTRICT begin = static_cast<char*>(dest);
     char *C4_RESTRICT end   = begin + (num_times * pattern_size);

--- a/src/c4/substr.hpp
+++ b/src/c4/substr.hpp
@@ -385,7 +385,7 @@ public:
     C4_ALWAYS_INLINE C4_PURE int compare(C const c) const noexcept
     {
         C4_XASSERT((str != nullptr) || len == 0);
-        if(C4_LIKELY(str != nullptr && len > 0))
+        if C4_LIKELY(str != nullptr && len > 0)
             return (*str != c) ? *str - c : (static_cast<int>(len) - 1);
         else
             return -1;
@@ -393,12 +393,13 @@ public:
 
     C4_PURE int compare(C const* C4_RESTRICT that, size_t sz) const noexcept
     {
+        C4_SUPPRESS_WARNING_GCC_PUSH
         #if defined(__GNUC__) && (__GNUC__ >= 6)
-        C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Wnull-dereference")
+        C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
         #endif
         C4_XASSERT(that || sz  == 0);
         C4_XASSERT(str  || len == 0);
-        if(C4_LIKELY(str && that))
+        if C4_LIKELY(str && that)
         {
             {
                 const size_t min = len < sz ? len : sz;
@@ -419,9 +420,7 @@ public:
             return 0;
         }
         return len < sz ? -1 : 1;
-        #if defined(__GNUC__) && (__GNUC__ >= 6)
         C4_SUPPRESS_WARNING_GCC_POP
-        #endif
     }
 
     template<class CharPtr>
@@ -484,7 +483,7 @@ public:
     /** true if that is a substring of *this (ie, from the same buffer) */
     C4_ALWAYS_INLINE C4_PURE bool is_super(ro_substr const that) const noexcept
     {
-        if(C4_LIKELY(len > 0))
+        if C4_LIKELY(len > 0)
             return that.str >= str && that.str+that.len <= str+len;
         else
             return that.len == 0 && that.str == str && str != nullptr;
@@ -1809,7 +1808,7 @@ public:
      * is an empty string, the output string is the empty string. */
     bool next_split(C sep, size_t *C4_RESTRICT start_pos, basic_substring *C4_RESTRICT out) const
     {
-        if(C4_LIKELY(*start_pos < len))
+        if C4_LIKELY(*start_pos < len)
         {
             for(size_t i = *start_pos; i < len; i++)
             {
@@ -1925,7 +1924,7 @@ public:
      */
     basic_substring pop_right(C sep=C('/'), bool skip_empty=false) const
     {
-        if(C4_LIKELY(len > 1))
+        if C4_LIKELY(len > 1)
         {
             auto pos = last_of(sep);
             if(pos != npos)
@@ -1978,7 +1977,7 @@ public:
      * the reciprocal part. */
     basic_substring pop_left(C sep = C('/'), bool skip_empty=false) const
     {
-        if(C4_LIKELY(len > 1))
+        if C4_LIKELY(len > 1)
         {
             auto pos = first_of(sep);
             if(pos != npos)

--- a/test/test_dump.cpp
+++ b/test/test_dump.cpp
@@ -68,7 +68,7 @@ void printf(csubstr fmt, Args&& ...args)
 {
     static thread_local std::string writebuf(16, '\0');
     DumpResults results = format_dump_resume<&test_dumper>(c4::to_substr(writebuf), fmt, std::forward<Args>(args)...);
-    if(C4_UNLIKELY(results.bufsize > writebuf.size())) // bufsize will be that of the largest element serialized. Eg int(1), will require 1 byte.
+    if C4_UNLIKELY(results.bufsize > writebuf.size()) // bufsize will be that of the largest element serialized. Eg int(1), will require 1 byte.
     {
         size_t dup = 2 * writebuf.size();
         writebuf.resize(dup > results.bufsize ? dup : results.bufsize);


### PR DESCRIPTION
  - [**BREAKING**] `C4_LIKELY()` and `C4_UNLIKELY()` now use `[[likely]]` and `[[unlikely]]` in C++20. Every use of this macro needs to refactored:
    ```c++
    if(C4_LIKELY(condition)) ... // error now
    // needs to be rewritten as:
    if C4_LIKELY(condition)  ...
    // same for C4_UNLIKELY
    ```
  - Add `C4_LIKELY20` and `C4_UNLIKELY20`, which resolve directly into `[[likely]]` and `[[unlikely]]` when C++ is 20 or later, or nothing otherwise.
  - Add C++23 detection (`C4_CPP` and `C4_CPP23`)
